### PR TITLE
Automatically resolve `pathlib.Path` types in `AppConfig`

### DIFF
--- a/taps/apps/app.py
+++ b/taps/apps/app.py
@@ -2,12 +2,21 @@ from __future__ import annotations
 
 import abc
 import pathlib
+import sys
+from typing import Any
 from typing import Protocol
 from typing import runtime_checkable
 from typing import TYPE_CHECKING
 
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
+    from typing import Self
+else:  # pragma: <3.11 cover
+    from typing_extensions import Self
+
 from pydantic import BaseModel
 from pydantic import ConfigDict
+from pydantic import field_serializer
+from pydantic import model_validator
 
 if TYPE_CHECKING:
     from taps.engine import Engine
@@ -34,6 +43,9 @@ class AppConfig(BaseModel, abc.ABC):
     """Application config protocol.
 
     Application configs must define the `create_app()` method.
+
+    After instantiation, all [`pathlib.Path`][pathlib.Path] types will
+    be resolved to convert them to absolute paths.
     """
 
     name: str
@@ -48,3 +60,16 @@ class AppConfig(BaseModel, abc.ABC):
     def get_app(self) -> App:
         """Initialize an app instance from this config."""
         ...
+
+    @field_serializer('*')
+    def _serialize_path_as_str(self, field: Any) -> Any:
+        if isinstance(field, pathlib.Path):
+            return str(field)
+        return field
+
+    @model_validator(mode='after')
+    def _resolve_path_types(self) -> Self:
+        for name, value in self:
+            if isinstance(value, pathlib.Path):
+                setattr(self, name, value.resolve())
+        return self

--- a/taps/apps/configs/docking.py
+++ b/taps/apps/configs/docking.py
@@ -4,7 +4,6 @@ import pathlib
 from typing import Literal
 
 from pydantic import Field
-from pydantic import field_validator
 
 from taps.apps.app import App
 from taps.apps.app import AppConfig
@@ -16,13 +15,13 @@ class DockingConfig(AppConfig):
     """Docking application configuration."""
 
     name: Literal['docking'] = 'docking'
-    smi_file_name_ligand: str = Field(
+    smi_file_name_ligand: pathlib.Path = Field(
         description='absolute path to ligand SMILES string',
     )
-    receptor: str = Field(
+    receptor: pathlib.Path = Field(
         description='absolute path to target receptor pdbqt file',
     )
-    tcl_path: str = Field(description='absolute path to TCL script')
+    tcl_path: pathlib.Path = Field(description='absolute path to TCL script')
     initial_simulations: int = Field(
         8,
         description='initial number of simulations to perform',
@@ -36,16 +35,6 @@ class DockingConfig(AppConfig):
         description='number of simulations per iteration',
     )
     seed: int = Field(0, description='random seed for sampling')
-
-    @field_validator(
-        'smi_file_name_ligand',
-        'receptor',
-        'tcl_path',
-        mode='before',
-    )
-    @classmethod
-    def _resolve_filepaths(cls, path: str) -> str:
-        return str(pathlib.Path(path).resolve())
 
     def get_app(self) -> App:
         """Create an application instance from the config."""

--- a/taps/apps/configs/fedlearn.py
+++ b/taps/apps/configs/fedlearn.py
@@ -27,8 +27,8 @@ class FedlearnConfig(AppConfig):
             'training and testing dataset (cifar10, cifar100, fmnist, mnist)'
         ),
     )
-    data_dir: str = Field(
-        'data/fedlearn',
+    data_dir: pathlib.Path = Field(
+        pathlib.Path('data/fedlearn'),
         description='download directory for data',
     )
     device: str = Field('cpu', description='device to use (e.g., cpu or cuda)')
@@ -59,11 +59,6 @@ class FedlearnConfig(AppConfig):
         description='evaluate the global model on test data after each round',
     )
     seed: Optional[int] = Field(None, description='random seed')  # noqa: UP007
-
-    @field_validator('data_dir', mode='before')
-    @classmethod
-    def _resolve_data_root(cls, root: str) -> str:
-        return str(pathlib.Path(root).resolve())
 
     @field_validator('dataset', mode='after')
     @classmethod

--- a/taps/apps/configs/mapreduce.py
+++ b/taps/apps/configs/mapreduce.py
@@ -5,7 +5,6 @@ from typing import Literal
 from typing import Optional
 
 from pydantic import Field
-from pydantic import field_validator
 
 from taps.apps.app import App
 from taps.apps.app import AppConfig
@@ -17,7 +16,7 @@ class MapreduceConfig(AppConfig):
     """Mapreduce application configuration."""
 
     name: Literal['mapreduce'] = 'mapreduce'
-    data_dir: str = Field(description='text file directory')
+    data_dir: pathlib.Path = Field(description='text file directory')
     map_tasks: Optional[int] = Field(  # noqa: UP007
         32,
         description=(
@@ -40,11 +39,6 @@ class MapreduceConfig(AppConfig):
         10000,
         description='number of words to generate per file',
     )
-
-    @field_validator('data_dir', mode='before')
-    @classmethod
-    def _resolve_paths(cls, path: str) -> str:
-        return str(pathlib.Path(path).resolve())
 
     def get_app(self) -> App:
         """Create an application instance from the config."""

--- a/taps/apps/configs/moldesign.py
+++ b/taps/apps/configs/moldesign.py
@@ -4,7 +4,6 @@ import pathlib
 from typing import Literal
 
 from pydantic import Field
-from pydantic import field_validator
 
 from taps.apps.app import App
 from taps.apps.app import AppConfig
@@ -16,7 +15,7 @@ class MoldesignConfig(AppConfig):
     """Moldesign application configuration."""
 
     name: Literal['moldesign'] = 'moldesign'
-    dataset: str = Field(description='molecule search space dataset')
+    dataset: pathlib.Path = Field(description='molecule search space dataset')
     initial_count: int = Field(8, description='number of initial calculations')
     search_count: int = Field(
         64,
@@ -29,11 +28,6 @@ class MoldesignConfig(AppConfig):
         ),
     )
     seed: int = Field(0, description='random seed')
-
-    @field_validator('dataset', mode='before')
-    @classmethod
-    def _resolve_dataset_path(cls, value: str) -> str:
-        return str(pathlib.Path(value).resolve())
 
     def get_app(self) -> App:
         """Create an application instance from the config."""

--- a/taps/apps/configs/montage.py
+++ b/taps/apps/configs/montage.py
@@ -4,7 +4,6 @@ import pathlib
 from typing import Literal
 
 from pydantic import Field
-from pydantic import field_validator
 
 from taps.apps.app import App
 from taps.apps.app import AppConfig
@@ -16,7 +15,11 @@ class MontageConfig(AppConfig):
     """Montage application configuration."""
 
     name: Literal['montage'] = 'montage'
-    img_folder: str = Field(description='input images folder path')
+    img_folder: pathlib.Path = Field(description='input images folder path')
+    # Note: the following are annotated as str rather than pathlib.Path
+    # because we don't want the AppConfig model_validator to convert
+    # them to absolute paths. They are relative to whatever the run
+    # directory is.
     img_tbl: str = Field(
         'Kimages.tbl',
         description='input image table filename',
@@ -32,11 +35,6 @@ class MontageConfig(AppConfig):
             '(relative to run directory)'
         ),
     )
-
-    @field_validator('img_folder', mode='before')
-    @classmethod
-    def _resolve_paths(cls, root: str) -> str:
-        return str(pathlib.Path(root).resolve())
 
     def get_app(self) -> App:
         """Create an application instance from the config."""

--- a/taps/apps/fedlearn/app.py
+++ b/taps/apps/fedlearn/app.py
@@ -66,7 +66,7 @@ class FedlearnApp:
         batch_size: int,
         epochs: int,
         lr: float,
-        data_dir: str = 'data/',
+        data_dir: pathlib.Path,
         device: str = 'cpu',
         download: bool = False,
         train: bool = True,

--- a/taps/apps/moldesign/app.py
+++ b/taps/apps/moldesign/app.py
@@ -34,7 +34,7 @@ class MoldesignApp:
 
     def __init__(
         self,
-        dataset: str,
+        dataset: pathlib.Path,
         initial_count: int = 8,
         search_count: int = 64,
         batch_size: int = 4,

--- a/taps/executor/config.py
+++ b/taps/executor/config.py
@@ -13,7 +13,7 @@ class ExecutorConfig(BaseModel, abc.ABC):
     name: str
 
     model_config: ConfigDict = ConfigDict(  # type: ignore[misc]
-        extra='forbid',
+        extra='ignore',
         validate_default=True,
         validate_return=True,
     )

--- a/taps/filter/config.py
+++ b/taps/filter/config.py
@@ -21,7 +21,7 @@ class FilterConfig(BaseModel, abc.ABC):
     name: str = Field(description='name of filter type')
 
     model_config: ConfigDict = ConfigDict(  # type: ignore[misc]
-        extra='forbid',
+        extra='ignore',
         validate_default=True,
         validate_return=True,
     )

--- a/taps/run/config.py
+++ b/taps/run/config.py
@@ -128,7 +128,6 @@ class Config(BaseSettings):
             exclude_unset=False,
             exclude_defaults=False,
             exclude_none=True,
-            serialize_as_any=True,
         )
 
         filepath = pathlib.Path(filepath)

--- a/taps/run/parse.py
+++ b/taps/run/parse.py
@@ -160,8 +160,9 @@ This behavior applies to all plugin types.
     base_options = {**toml_options, **base_options}
     if 'app.name' not in base_options or base_options['app.name'] is None:
         raise ValueError(
-            'Missing the app name option. Either provides --app {APP} via '
-            'the CLI args or add the app.name attribute the config file.',
+            'App name option is required. Either pass --app {APP} via the'
+            'CLI arguments or add the app.name attribute to the config '
+            'file with --config {PATH}.',
         )
 
     app_group.description = f'selected app: {base_options["app.name"]}'

--- a/taps/transformer/config.py
+++ b/taps/transformer/config.py
@@ -16,7 +16,7 @@ class TransformerConfig(BaseModel, abc.ABC):
     name: str = Field(description='name of transformer type')
 
     model_config: ConfigDict = ConfigDict(  # type: ignore[misc]
-        extra='forbid',
+        extra='ignore',
         validate_default=True,
         validate_return=True,
     )

--- a/tests/apps/app_test.py
+++ b/tests/apps/app_test.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pathlib
+
+from taps.apps.app import App
+from taps.apps.app import AppConfig
+
+
+def test_parse_config_paths() -> None:
+    class TestConfig(AppConfig):
+        name: str
+        path: pathlib.Path
+
+        def get_app(self) -> App:
+            raise NotImplementedError
+
+    # AppConfig should parse str to pathlib.Path then force
+    # paths to be absolute.
+    config = TestConfig(name='test', path='test-parse-config-paths')
+    assert config.path.is_absolute()
+
+    # AppConfig should serialize all pathlib.Path types as
+    # strings.
+    dump = config.model_dump()
+    assert isinstance(dump['path'], str)

--- a/tests/engine/engine_test.py
+++ b/tests/engine/engine_test.py
@@ -95,7 +95,15 @@ def test_app_engine_record_logging(
 
         # Four tasks: task1, task2, and the two tasks in the map
         assert len(logger.records) == 4  # noqa: PLR2004
-        assert str(task1.info.task_id) in logger.records[1]['parent_task_ids']
+
+        for record in logger.records:
+            if record['task_id'] == str(task2.info.task_id):
+                assert str(task1.info.task_id) in record['parent_task_ids']
+                break
+        else:  # pragma: no cover
+            raise RuntimeError(
+                f'Did not find record for task {task1.info.task_id}',
+            )
 
 
 def test_app_engine_record_logging_exception(

--- a/tests/run/parse_test.py
+++ b/tests/run/parse_test.py
@@ -26,14 +26,14 @@ def test_exit_on_only_help(capsys) -> None:
 
 
 def test_parse_args_missing_app(tmp_path: pathlib.Path) -> None:
-    with pytest.raises(ValueError, match='Missing the app name option.'):
+    with pytest.raises(ValueError, match='App name option is required.'):
         parse_args_to_config(['--engine.executor', 'process-pool'])
 
     config_file = tmp_path / 'config.toml'
     with open(config_file, 'w') as f:
         f.write('[app]')
 
-    with pytest.raises(ValueError, match='Missing the app name option.'):
+    with pytest.raises(ValueError, match='App name option is required.'):
         parse_args_to_config(['--config', str(config_file)])
 
 


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Automatically resolve `pathlib.Path` types in `AppConfig` so that absolute paths are created on initialization. This removes the need for the custom field validators to avoid unexpected relative path failures when `taps.run` changes the CWD to the `run_dir`.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #44 

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Added tests, and testing with the `fedlearn` app.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
