### PR TITLE
Rename default transformer filter behavior to "all"

### DIFF
--- a/docs/guides/data.md
+++ b/docs/guides/data.md
@@ -75,10 +75,11 @@ In order to ensure that the registration is performed, the `FooTransformerConfig
 ## Filter Types
 
 As mentioned above, a [`Filter`][taps.filter.filters.Filter] determine what objects (i.e., task arguments and/or results) get passed to the transformer.
-The default filter, [`NullFilter`][taps.filter.filters.NullFilter], lets all objects through.
+The default filter, [`AllFilter`][taps.filter.filters.AllFilter], lets all objects through.
 
 Other [`Filter`][taps.filter.filters.Filter] types are provided to give fine-grained control over what objects get transformed.
 
+* [`NullFilter`][taps.filter.filters.NullFilter] (`#!toml name = "null"`): no objects are transformed.
 * [`ObjectSizeFilter`][taps.filter.filters.ObjectSizeFilter] (`#!toml name = "object-size"`): checks if the size of an object (computed using [`sys.getsizeof()`][sys.getsizeof]) is greater than a minimum size and less than a maximum size.
 * [`PickleSizeFilter`][taps.filter.filters.PickleSizeFilter] (`#!toml name = "pickle-size"`): checks if the size of an object (computed using the size of the pickled object) is greater than a minimum size and less than a maximum size.
 * [`ObjectTypeFilter`][taps.filter.filters.ObjectTypeFilter] (`#!toml name = "object-type"`): checks if the object is of a certain type.

--- a/taps/engine/config.py
+++ b/taps/engine/config.py
@@ -10,8 +10,8 @@ from pydantic import Field
 from taps.engine.engine import Engine
 from taps.executor import ExecutorConfig
 from taps.executor import ProcessPoolConfig
+from taps.filter import AllFilterConfig
 from taps.filter import FilterConfig
-from taps.filter import NullFilterConfig
 from taps.record import JSONRecordLogger
 from taps.transformer import NullTransformerConfig
 from taps.transformer import TransformerConfig
@@ -29,7 +29,7 @@ class EngineConfig(BaseModel):
     """
 
     executor: ExecutorConfig = Field(default_factory=ProcessPoolConfig)
-    filter: FilterConfig = Field(default_factory=NullFilterConfig)
+    filter: FilterConfig = Field(default_factory=AllFilterConfig)
     transformer: TransformerConfig = Field(
         default_factory=NullTransformerConfig,
     )

--- a/taps/filter/__init__.py
+++ b/taps/filter/__init__.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from taps.filter.config import AllFilterConfig
 from taps.filter.config import FilterConfig
 from taps.filter.config import NullFilterConfig
 from taps.filter.config import ObjectSizeConfig
 from taps.filter.config import PickleSizeConfig
+from taps.filter.filters import AllFilter
 from taps.filter.filters import Filter
 from taps.filter.filters import NullFilter
 from taps.filter.filters import ObjectSizeFilter

--- a/taps/filter/config.py
+++ b/taps/filter/config.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
 
+from taps.filter.filters import AllFilter
 from taps.filter.filters import Filter
 from taps.filter.filters import NullFilter
 from taps.filter.filters import ObjectSizeFilter
@@ -30,6 +31,17 @@ class FilterConfig(BaseModel, abc.ABC):
     def get_filter(self) -> Filter:
         """Create a filter from the configuration."""
         ...
+
+
+@register('filter')
+class AllFilterConfig(FilterConfig):
+    """All filter configuration."""
+
+    name: Literal['all'] = Field('all', description='name of filter type')
+
+    def get_filter(self) -> Filter:
+        """Create a filter from the configuration."""
+        return AllFilter()
 
 
 @register('filter')

--- a/taps/filter/filters.py
+++ b/taps/filter/filters.py
@@ -17,12 +17,20 @@ class Filter(Protocol):
         ...
 
 
-class NullFilter:
-    """Null filter that lets all objects pass through."""
+class AllFilter:
+    """All filter that lets all objects pass through."""
 
     def __call__(self, obj: Any) -> bool:
         """Check if an object passes through the filter."""
         return True
+
+
+class NullFilter:
+    """Null filter that lets no objects pass through."""
+
+    def __call__(self, obj: Any) -> bool:
+        """Check if an object passes through the filter."""
+        return False
 
 
 class ObjectSizeFilter:

--- a/taps/run/config.py
+++ b/taps/run/config.py
@@ -154,7 +154,7 @@ def _make_config_cls(options: dict[str, Any]) -> type[Config]:
         description=f'selected executor: {executor_name}',
     )
 
-    filter_name = options.get('engine.filter.name', 'null')
+    filter_name = options.get('engine.filter.name', 'all')
     filter_cls = get_filter_configs()[filter_name]
     filter_field = Field(
         default_factory=filter_cls,

--- a/taps/run/parse.py
+++ b/taps/run/parse.py
@@ -130,7 +130,7 @@ This behavior applies to all plugin types.
         default=argparse.SUPPRESS,
         dest='engine.filter.name',
         metavar='FILTER',
-        help='filter choice {%(choices)s} (default: null)',
+        help='filter choice {%(choices)s} (default: all)',
     )
     engine_group.add_argument(
         '--engine.transformer',

--- a/tests/engine/transform_test.py
+++ b/tests/engine/transform_test.py
@@ -5,7 +5,7 @@ from typing import Any
 from typing import TypeVar
 
 from taps.engine.transform import TaskTransformer
-from taps.filter import NullFilter
+from taps.filter import AllFilter
 from taps.filter import ObjectTypeFilter
 
 T = TypeVar('T')
@@ -31,7 +31,7 @@ class DictTransformer:
 
 
 def test_task_data_transfomer() -> None:
-    transformer = TaskTransformer(DictTransformer(), NullFilter())
+    transformer = TaskTransformer(DictTransformer(), AllFilter())
 
     obj = object()
     identifier = transformer.transform(obj)
@@ -42,7 +42,7 @@ def test_task_data_transfomer() -> None:
 
 
 def test_task_data_transfomer_iterable() -> None:
-    transformer = TaskTransformer(DictTransformer(), NullFilter())
+    transformer = TaskTransformer(DictTransformer(), AllFilter())
 
     objs = (object(), object())
     identifiers = transformer.transform_iterable(objs)
@@ -53,7 +53,7 @@ def test_task_data_transfomer_iterable() -> None:
 
 
 def test_task_data_transfomer_mapping() -> None:
-    transformer = TaskTransformer(DictTransformer(), NullFilter())
+    transformer = TaskTransformer(DictTransformer(), AllFilter())
 
     objs = {'a': object(), 'b': object()}
     identifiers = transformer.transform_mapping(objs)

--- a/tests/filter/config_test.py
+++ b/tests/filter/config_test.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
 
+from taps.filter.config import AllFilterConfig
 from taps.filter.config import NullFilterConfig
 from taps.filter.config import ObjectSizeConfig
 from taps.filter.config import PickleSizeConfig
+from taps.filter.filters import AllFilter
 from taps.filter.filters import Filter
+from taps.filter.filters import NullFilter
+
+
+def test_all_filter_config() -> None:
+    config = AllFilterConfig()
+    assert isinstance(config.get_filter(), AllFilter)
 
 
 def test_null_filter_config() -> None:
     config = NullFilterConfig()
-
-    assert isinstance(config.get_filter(), Filter)
+    assert isinstance(config.get_filter(), NullFilter)
 
 
 def test_object_size_filter() -> None:

--- a/tests/filter/filters_test.py
+++ b/tests/filter/filters_test.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
+from taps.filter import AllFilter
 from taps.filter import NullFilter
 from taps.filter import ObjectSizeFilter
 from taps.filter import ObjectTypeFilter
 from taps.filter import PickleSizeFilter
 
 
+def test_all_filter() -> None:
+    filter_ = AllFilter()
+    assert filter_(object())
+
+
 def test_null_filter() -> None:
     filter_ = NullFilter()
-    assert filter_(object())
+    assert not filter_(object())
 
 
 def test_object_size_filter() -> None:


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Adds the `AllFilter`, which behaves likes the old `NullFilter`, and make it the default. `NullFilter` now lets nothing through the filter. I.e., no objects will be transformer. I think this naming is more clear.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
