### PR TITLE
Increase timedelta in directory creation check

### DIFF
--- a/tests/run/config_test.py
+++ b/tests/run/config_test.py
@@ -95,6 +95,6 @@ def test_make_run_dir(tmp_path: pathlib.Path) -> None:
     assert name == config.app.name
     assert executor == config.engine.executor.name
 
-    # Check timestamp is < 1 second from now
+    # Check timestamp is < 5 seconds from now
     timestamp = datetime.strptime(timestamp_str, '%Y-%m-%d-%H-%M-%S')
-    assert datetime.now() - timestamp < timedelta(seconds=1)
+    assert datetime.now() - timestamp < timedelta(seconds=5)


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

The directory timestamp does not contain millisecond precision so if the directory is created towards the end of a second (e.g., 900ms) and the check takes place right after the second (e.g., 1.100 ms), due to rounding, it can appear as taking 2 seconds to create the directory (even though it only took 200 ms).

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes this recurring test failure: https://github.com/proxystore/taps/actions/runs/9895358544/job/27335051577

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Tests pass now.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
