### PR TITLE
Fix Dask `Future`s getting proxied in chained tasks

### DIFF
--- a/taps/engine/__init__.py
+++ b/taps/engine/__init__.py
@@ -8,6 +8,7 @@ from taps.engine._engine import ExecutionInfo
 from taps.engine._engine import TaskFuture
 from taps.engine._engine import TaskInfo
 from taps.engine._engine import wait
+from taps.engine._protocols import FutureProtocol
 from taps.engine._transform import TaskTransformer
 
 __all__ = (
@@ -15,6 +16,7 @@ __all__ = (
     'EngineConfig',
     'ExceptionInfo',
     'ExecutionInfo',
+    'FutureProtocol',
     'TaskFuture',
     'TaskInfo',
     'TaskTransformer',

--- a/taps/engine/_protocols.py
+++ b/taps/engine/_protocols.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+from typing import Callable
+from typing import Protocol
+from typing import runtime_checkable
+from typing import TypeVar
+
+R = TypeVar('R')
+
+
+@runtime_checkable
+class FutureProtocol(Protocol[R]):
+    """Future protocol.
+
+    This [`Protocol`][typing.Protocol] is useful for type checking future
+    types that do not inherit from [`Future`][concurrent.futures.Future]
+    (such as Dask's [`Future`][distributed.Future].
+
+    This protocol does not require `running()` because Dask does not provide
+    that method.
+    """
+
+    def add_done_callback(
+        self,
+        callback: Callable[[FutureProtocol[R]], Any],
+    ) -> None:
+        """Add a done callback to the future."""
+        ...
+
+    def cancel(self) -> bool:
+        """Attempt to cancel the task."""
+        ...
+
+    def cancelled(self) -> bool:
+        """Check if the task was cancelled."""
+        ...
+
+    def done(self) -> bool:
+        """Check if the task is done."""
+        ...
+
+    def exception(self, timeout: float | None = None) -> BaseException | None:
+        """Get the exception raised by the task."""
+        ...
+
+    def result(self, timeout: float | None = None) -> R:
+        """Get the result of the task."""
+        ...

--- a/taps/engine/_transform.py
+++ b/taps/engine/_transform.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from concurrent.futures import Future
 from typing import Any
 from typing import Generic
 from typing import Iterable
 from typing import Mapping
 from typing import TypeVar
 
+from taps.engine._protocols import FutureProtocol
 from taps.filter import Filter
 from taps.transformer import Transformer
 
@@ -47,7 +47,7 @@ class TaskTransformer(Generic[IdentifierT]):
         Transforms `obj` into an identifier if it passes the filter check.
         The identifier can later be used to resolve the object.
         """
-        if self.filter_(obj) and not isinstance(obj, Future):
+        if self.filter_(obj) and not isinstance(obj, FutureProtocol):
             return self.transformer.transform(obj)
         else:
             return obj

--- a/taps/executor/dask.py
+++ b/taps/executor/dask.py
@@ -81,7 +81,11 @@ class DaskDistributedExecutor(Executor):
         """
         # Based on the Parsl implementation.
         # https://github.com/Parsl/parsl/blob/7fba7d634ccade76618ee397d3c951c5cbf2cd49/parsl/concurrent/__init__.py#L58
-        futures = self.client.map(function, *iterables, batch_size=chunksize)
+        futures = self.client.map(
+            function,
+            *iterables,  # type: ignore[arg-type,unused-ignore]
+            batch_size=chunksize,
+        )
 
         def _result_iterator() -> Generator[T, None, None]:
             futures.reverse()

--- a/tests/engine/engine_test.py
+++ b/tests/engine/engine_test.py
@@ -144,6 +144,10 @@ def test_as_completed_dask(dask_executor: DaskDistributedExecutor) -> None:
         assert completed_results == set(range(1, 6))
 
 
+def test_as_completed_empty() -> None:
+    assert len(list(as_completed([]))) == 0
+
+
 def test_task_future_exception() -> None:
     future: Future[_TaskResult[int]] = Future()
 
@@ -192,3 +196,9 @@ def test_wait_dask(dask_executor: DaskDistributedExecutor) -> None:
         assert len(not_completed) == 0
         results = {task.result() for task in completed}
         assert results == set(range(1, 6))
+
+
+def test_wait_empty() -> None:
+    done, not_done = wait([])  # type: ignore[var-annotated]
+    assert len(done) == 0
+    assert len(not_done) == 0


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Checking `isinstance(obj, Future)` does not work with Dask futures so the data transformer was getting incorrectly applied to futures.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #112

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

The cholesky example from #112 works now.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
