### PR TITLE
Use non-deprecated Parsl provider for tests

### DIFF
--- a/tests/executor/parsl_test.py
+++ b/tests/executor/parsl_test.py
@@ -142,7 +142,7 @@ def test_provider_config() -> None:
 
 
 def test_provider_config_default() -> None:
-    config = ProviderConfig(kind='AdHocProvider')
+    config = ProviderConfig(kind='LocalProvider')
     assert isinstance(config.get_provider(), ExecutionProvider)
 
 


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

The `AdHocProvider` was recently deprecated.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->
<!--- Otherwise, write N/A --->

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [x] Internal (refactoring, performance, and testing)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (no changes to the code)
- [ ] Development (CI workflows, packages, templates, etc.)
- [ ] Package (package dependencies and versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, documentation, enhancement, package, etc.).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
