### PR TITLE
Create `Config` docstrings from `Field` descriptions

### DIFF
--- a/docs/guides/apps.md
+++ b/docs/guides/apps.md
@@ -124,9 +124,9 @@ from taps.plugins import register
 class FoobarConfig(AppConfig):
     """Foobar application configuration."""
 
-    name: Literal['foobar'] = 'foobar'
-    message: str = Field(description='message to print')
-    repeat: int = Field(1, description='number of times to repeat message')
+    name: Literal['foobar'] = Field('foobar', description='Application name.')
+    message: str = Field(description='Message to print.')
+    repeat: int = Field(1, description='Number of times to repeat message.')
 
     def get_app(self) -> App:
         """Create an application instance from the config."""

--- a/docs/guides/executor.md
+++ b/docs/guides/executor.md
@@ -226,16 +226,12 @@ class SyncExecutor(Executor):
 
 @register('executor')
 class SyncExecutorConfig(ExecutorConfig):
-    """Synchronous executor configuration.
+    """Synchronous executor configuration."""
 
-    Attributes:
-        sleep: Time to sleep before executing tasks.
-    """
-
-    name: Literal['sync'] = 'sync'
+    name: Literal['sync'] = Field('sync', description='Executor name.')
     sleep: float = Field(
         0,
-        description='time to sleep before executing tasks',
+        description='Time to sleep before executing tasks.',
     )
 
     def get_executor(self) -> FutureDependencyExecutor:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -174,6 +174,8 @@ plugins:
             annotations_path: brief
             docstring_section_style: list
             docstring_style: google
+            extensions:
+              - griffe_fieldz: {include_inherited: true}
             inherited_members: yes
             line_length: 60
             members_order: source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
 ]
 docs = [
     "black==24.4.2",
+    "griffe-fieldz==0.2.0",
     "mkdocs-click==0.8.1",
     "mkdocs-gen-files==0.5.0",
     "mkdocs-literate-nav==0.6.1",

--- a/taps/apps/configs/cholesky.py
+++ b/taps/apps/configs/cholesky.py
@@ -20,9 +20,12 @@ from taps.plugins import register
 class CholeskyConfig(AppConfig):
     """Cholesky application configuration."""
 
-    name: Literal['cholesky'] = 'cholesky'
-    matrix_size: int = Field(description='size of the square matrix')
-    block_size: int = Field(description='block size')
+    name: Literal['cholesky'] = Field(
+        'cholesky',
+        description='Application name.',
+    )
+    matrix_size: int = Field(description='Size of initial square matrix.')
+    block_size: int = Field(description='Block size for tiled decomposition.')
 
     @model_validator(mode='after')
     def _validate_sizes(self) -> Self:

--- a/taps/apps/configs/docking.py
+++ b/taps/apps/configs/docking.py
@@ -14,27 +14,30 @@ from taps.plugins import register
 class DockingConfig(AppConfig):
     """Docking application configuration."""
 
-    name: Literal['docking'] = 'docking'
+    name: Literal['docking'] = Field(
+        'docking',
+        description='Application name.',
+    )
     smi_file_name_ligand: pathlib.Path = Field(
-        description='absolute path to ligand SMILES string',
+        description='Ligand SMILES string filepath.',
     )
     receptor: pathlib.Path = Field(
-        description='absolute path to target receptor pdbqt file',
+        description='Target receptor pdbqt filepath.',
     )
-    tcl_path: pathlib.Path = Field(description='absolute path to TCL script')
+    tcl_path: pathlib.Path = Field(description='TCL script path.')
     initial_simulations: int = Field(
         8,
-        description='initial number of simulations to perform',
+        description='Number of initial simulations.',
     )
     num_iterations: int = Field(
         3,
-        description='number of infer-simulate-train loops to perform',
+        description='Number of infer-simulate-train loops.',
     )
     batch_size: int = Field(
         8,
-        description='number of simulations per iteration',
+        description='Number of simulations per iteration.',
     )
-    seed: int = Field(0, description='random seed for sampling')
+    seed: int = Field(0, description='Random seed for sampling.')
 
     def get_app(self) -> App:
         """Create an application instance from the config."""

--- a/taps/apps/configs/failures.py
+++ b/taps/apps/configs/failures.py
@@ -24,16 +24,19 @@ from taps.plugins import register
 class FailureInjectionConfig(AppConfig, use_enum_values=True):
     """Failure injection configuration."""
 
-    name: Literal['failures'] = 'failures'
-    base: str = Field(description='base app to inject failures into')
+    name: Literal['failures'] = Field(
+        'failures',
+        description='Application name.',
+    )
+    base: str = Field(description='Base app to inject failures into.')
     config: Dict[str, Any] = Field(  # noqa: UP006
         default_factory=dict,
-        description='base app configuration',
+        description='Base app configuration.',
     )
-    failure_rate: float = Field(1, description='task failure rate')
+    failure_rate: float = Field(1, description='Task failure rate.')
     failure_type: FailureType = Field(
         FailureType.DEPENDENCY,
-        description='task failure type',
+        description='Task failure type.',
     )
 
     @field_validator('base', mode='before')

--- a/taps/apps/configs/fedlearn.py
+++ b/taps/apps/configs/fedlearn.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pathlib
+from typing import Any
 from typing import Literal
 from typing import Optional
 
@@ -67,8 +68,10 @@ class FedlearnConfig(AppConfig, use_enum_values=True):
 
     @field_validator('dataset', mode='before')
     @classmethod
-    def _validate_dataset(cls, value: str) -> str:
-        return value.lower()
+    def _validate_dataset(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return value.lower()
+        return value
 
     def get_app(self) -> App:
         """Create an application instance from the config."""

--- a/taps/apps/configs/mapreduce.py
+++ b/taps/apps/configs/mapreduce.py
@@ -15,29 +15,32 @@ from taps.plugins import register
 class MapreduceConfig(AppConfig):
     """Mapreduce application configuration."""
 
-    name: Literal['mapreduce'] = 'mapreduce'
-    data_dir: pathlib.Path = Field(description='text file directory')
+    name: Literal['mapreduce'] = Field(
+        'mapreduce',
+        description='Application name.',
+    )
+    data_dir: pathlib.Path = Field(description='Text file directory.')
     map_tasks: Optional[int] = Field(  # noqa: UP007
         32,
         description=(
-            'maximum number of map tasks (none, the default, uses one '
-            'map task per input file)'
+            'Maximum number of map tasks (`None` uses one '
+            'map task per input file).'
         ),
     )
     generate: bool = Field(
         False,
         description=(
-            'generate random text files in --data-dir rather than '
-            'reading existing files'
+            'Generate random text files in data-dir rather than '
+            'reading existing files.'
         ),
     )
     generated_files: int = Field(
         10,
-        description='number of text files to generate',
+        description='Number of text files to generate.',
     )
     generated_words: int = Field(
         10000,
-        description='number of words to generate per file',
+        description='Number of words to generate per file.',
     )
 
     def get_app(self) -> App:

--- a/taps/apps/configs/moldesign.py
+++ b/taps/apps/configs/moldesign.py
@@ -14,20 +14,26 @@ from taps.plugins import register
 class MoldesignConfig(AppConfig):
     """Moldesign application configuration."""
 
-    name: Literal['moldesign'] = 'moldesign'
-    dataset: pathlib.Path = Field(description='molecule search space dataset')
-    initial_count: int = Field(8, description='number of initial calculations')
+    name: Literal['moldesign'] = Field(
+        'moldesign',
+        description='Application name.',
+    )
+    dataset: pathlib.Path = Field(description='Molecule search space dataset.')
+    initial_count: int = Field(
+        8,
+        description='Number of initial calculations.',
+    )
     search_count: int = Field(
         64,
-        description='number of molecules to evaluate in total',
+        description='Number of molecules to evaluate in total.',
     )
     batch_size: int = Field(
         4,
         description=(
-            'number of molecules to evaluate in each batch of simulations'
+            'Number of molecules to evaluate in each batch of simulations.'
         ),
     )
-    seed: int = Field(0, description='random seed')
+    seed: int = Field(0, description='Random seed.')
 
     def get_app(self) -> App:
         """Create an application instance from the config."""

--- a/taps/apps/configs/montage.py
+++ b/taps/apps/configs/montage.py
@@ -14,25 +14,30 @@ from taps.plugins import register
 class MontageConfig(AppConfig):
     """Montage application configuration."""
 
-    name: Literal['montage'] = 'montage'
-    img_folder: pathlib.Path = Field(description='input images folder path')
+    name: Literal['montage'] = Field(
+        'montage',
+        description='Application name.',
+    )
+    img_folder: pathlib.Path = Field(
+        description='Input images directory path.',
+    )
     # Note: the following are annotated as str rather than pathlib.Path
     # because we don't want the AppConfig model_validator to convert
     # them to absolute paths. They are relative to whatever the run
     # directory is.
     img_tbl: str = Field(
         'Kimages.tbl',
-        description='input image table filename',
+        description='Input image table filename.',
     )
     img_hdr: str = Field(
         'Kimages.hdr',
-        description='header filename for input images',
+        description='Header filename for input images.',
     )
     output_dir: str = Field(
         'data',
         description=(
-            'output folder path for intermediate and final data '
-            '(relative to run directory)'
+            'Output folder path for intermediate and final data '
+            '(relative to run directory).'
         ),
     )
 

--- a/taps/apps/configs/synthetic.py
+++ b/taps/apps/configs/synthetic.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import enum
 import sys
+from typing import Any
 from typing import Literal
 from typing import Optional
 
@@ -51,8 +52,10 @@ class SyntheticConfig(AppConfig, use_enum_values=True):
 
     @field_validator('structure', mode='before')
     @classmethod
-    def _validate_structure(cls, value: str) -> str:
-        return value.lower()
+    def _validate_structure(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return value.lower()
+        return value
 
     @model_validator(mode='after')
     def _validate_options(self) -> Self:

--- a/taps/apps/fedlearn/types.py
+++ b/taps/apps/fedlearn/types.py
@@ -5,6 +5,7 @@ import sys
 from typing import Any
 from typing import Dict
 from typing import Optional
+from typing import TYPE_CHECKING
 
 if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
     from typing import TypeAlias
@@ -14,8 +15,10 @@ else:  # pragma: <3.10 cover
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
-from torch import nn
-from torch.utils.data import Subset
+
+if TYPE_CHECKING:
+    from torch import nn
+    from torch.utils.data import Subset
 
 ClientID: TypeAlias = int
 """Integer IDs for `Client` instances."""

--- a/taps/apps/synthetic.py
+++ b/taps/apps/synthetic.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import enum
 import logging
 import os
 import pathlib
@@ -9,6 +8,7 @@ import sys
 import time
 import uuid
 
+from taps.apps.configs.synthetic import WorkflowStructure
 from taps.engine import as_completed
 from taps.engine import Engine
 from taps.engine import TaskFuture
@@ -277,15 +277,6 @@ def run_sequential(
 
     rate = task_count / (time.monotonic() - start)
     logger.log(APP_LOG_LEVEL, f'Task completion rate: {rate:.3f} tasks/s')
-
-
-class WorkflowStructure(enum.Enum):
-    """Workflow structure types."""
-
-    BAG = 'bag'
-    DIAMOND = 'diamond'
-    REDUCE = 'reduce'
-    SEQUENTIAL = 'sequential'
 
 
 class SyntheticApp:

--- a/taps/engine/_config.py
+++ b/taps/engine/_config.py
@@ -18,22 +18,24 @@ from taps.transformer import TransformerConfig
 
 
 class EngineConfig(BaseModel):
-    """App engine configuration.
+    """App engine configuration."""
 
-    Attributes:
-        executor: Executor configuration.
-        filter: Filter configuration.
-        transformer: Transformer configuration.
-        task_record_file_name: Name of line-delimited JSON file that task
-            records are logged to.
-    """
-
-    executor: ExecutorConfig = Field(default_factory=ProcessPoolConfig)
-    filter: FilterConfig = Field(default_factory=AllFilterConfig)
+    executor: ExecutorConfig = Field(
+        default_factory=ProcessPoolConfig,
+        description='Executor configuration.',
+    )
+    filter: FilterConfig = Field(
+        default_factory=AllFilterConfig,
+        description='Filter configuration.',
+    )
     transformer: TransformerConfig = Field(
         default_factory=NullTransformerConfig,
+        description='Transformer configuration',
     )
-    task_record_file_name: Optional[str] = Field('tasks.jsonl')  # noqa: UP007
+    task_record_file_name: Optional[str] = Field(  # noqa: UP007
+        'tasks.jsonl',
+        description='Name of line-delimted JSON file to log task records to.',
+    )
 
     model_config: ConfigDict = ConfigDict(  # type: ignore[misc]
         extra='forbid',

--- a/taps/engine/_engine.py
+++ b/taps/engine/_engine.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import dataclasses
 import sys
 import time
 import uuid
@@ -194,7 +193,7 @@ class Engine:
             task_future.info.success = True
             task_future.info.execution = execution_info
         task_future.info.received_time = time.time()
-        self.record_logger.log(dataclasses.asdict(task_future.info))
+        self.record_logger.log(task_future.info.model_dump())
 
     # Note: args/kwargs are typed as Any rather than P.args/P.kwargs
     # because the inputs may be TaskFuture types which will get translated

--- a/taps/engine/task.py
+++ b/taps/engine/task.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import dataclasses
 import functools
 import socket
 import sys
@@ -8,6 +7,8 @@ import time
 from typing import Any
 from typing import Callable
 from typing import Generic
+from typing import List
+from typing import Optional
 from typing import TypeVar
 
 if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
@@ -15,29 +16,24 @@ if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
 else:  # pragma: <3.10 cover
     from typing_extensions import ParamSpec
 
+from pydantic import BaseModel
+from pydantic import Field
+
 from taps.engine.transform import TaskTransformer
 
 P = ParamSpec('P')
 T = TypeVar('T')
 
 
-@dataclasses.dataclass
-class ExceptionInfo:
-    """Task exception information.
+class ExceptionInfo(BaseModel):
+    """Task exception information."""
 
-    Args:
-        type: Type of the raised exception.
-        message: Message of the raised exception.
-        traceback: Trackback of the raised exception.
-    """
-
-    type: str
-    message: str
-    traceback: str
+    type: str = Field(description='Exception type.')
+    message: str = Field(description='Exception message.')
+    traceback: str = Field(description='Exception traceback.')
 
 
-@dataclasses.dataclass
-class ExecutionInfo:
+class ExecutionInfo(BaseModel):
     """Task execution information.
 
     All times are Unix timestamps recorded on the worker process executing
@@ -57,69 +53,104 @@ class ExecutionInfo:
     |   + result_transform_end_time
     + execution_end_time
     ```
-
-    Args:
-        hostname: Name of the host the task was executed on.
-        execution_start_time: Unix timestamp indicating the task began
-            execution on a worker.
-        execution_end_time: Unix timestamp indicating the task finished
-            execution on a worker.
-        task_start_time: Unix timestamp indicating the start of execution
-            of the task function.
-        task_end_time: Unix timestamp indicating the end of execution
-            of the task function.
-        input_transform_start_time: Unix timestamp indicating the start
-            of resolving input arguments on the worker.
-        input_transform_end_time: Unix timestamp indicating the end
-            of resolving input arguments on the worker.
-        result_transform_start_time: Unix timestamp indicating the start
-            of transforming the task function result on the worker.
-        result_transform_end_time: Unix timestamp indicating the end
-            of transforming the task function result on the worker.
     """
 
-    hostname: str
-    execution_start_time: float
-    execution_end_time: float
-    task_start_time: float
-    task_end_time: float
-    input_transform_start_time: float
-    input_transform_end_time: float
-    result_transform_start_time: float
-    result_transform_end_time: float
+    hostname: str = Field(
+        description='Name of the host the task was executed on.',
+    )
+    execution_start_time: float = Field(
+        description=(
+            'Unix timestamp indicating the task began execution on a worker.'
+        ),
+    )
+    execution_end_time: float = Field(
+        description=(
+            'Unix timestamp indicating the task finished execution '
+            'on a worker.'
+        ),
+    )
+    task_start_time: float = Field(
+        description=(
+            'Unix timestamp indicating the start of execution of '
+            'the task function.'
+        ),
+    )
+    task_end_time: float = Field(
+        description=(
+            'Unix timestamp indicating the end of execution of '
+            'the task function.'
+        ),
+    )
+    input_transform_start_time: float = Field(
+        description=(
+            'Unix timestamp indicating the start of resolving input '
+            'arguments on the worker.'
+        ),
+    )
+    input_transform_end_time: float = Field(
+        description=(
+            'Unix timestamp indicating the end of resolving input '
+            'arguments on the worker.'
+        ),
+    )
+    result_transform_start_time: float = Field(
+        description=(
+            'Unix timestamp indicating the start of transforming the '
+            'task function result on the worker.'
+        ),
+    )
+    result_transform_end_time: float = Field(
+        description=(
+            'Unix timestamp indicating the end of transforming the '
+            'task function result on the worker.'
+        ),
+    )
 
 
-@dataclasses.dataclass
-class TaskInfo:
-    """Task execution information.
+class TaskInfo(BaseModel):
+    """Task execution information."""
 
-    Args:
-        task_id: Unique UUID of the task as determined by the engine.
-        function_name: Name of the task function.
-        parent_task_ids: UUIDs of parent tasks. A task is a child task if its
-            arguments contain a future to the result of another task.
-        submit_time: Unix timestamp indicating the engine submitted the task
-            to the executor.
-        received_time: Unix timestamp indicating the executor was notified the
-            task has completed. This is recorded in a callback on the task
-            future and thus includes any lag in invoking the future callbacks.
-        success: Boolean indicating if the task completed without raising an
-            exception.
-        exception: Task exception information.
-        execution: Task execution information.
-    """
+    task_id: str = Field(
+        description='Unique UUID of the task as determined by the engine.',
+    )
+    function_name: str = Field(description='Name of the task function.')
+    parent_task_ids: List[str] = Field(  # noqa: UP006
+        description=(
+            'UUIDs of parent tasks. A task is a child task if its arguments '
+            'contain a future to the result of another task.'
+        ),
+    )
+    submit_time: float = Field(
+        description=(
+            'Unix timestamp indicating the engine submitted the task '
+            'to the executor.'
+        ),
+    )
+    received_time: Optional[float] = Field(  # noqa: UP007
+        None,
+        description=(
+            'Unix timestamp indicating the executor was notified the task '
+            'has completed. This is recorded in a callback on the task future '
+            'and thus includes any lag in invoking the future callbacks.'
+        ),
+    )
+    success: Optional[bool] = Field(  # noqa: UP007
+        None,
+        description=(
+            'Boolean indicating if the task completed without raising '
+            'an exception.'
+        ),
+    )
+    exception: Optional[ExceptionInfo] = Field(  # noqa: UP007
+        None,
+        description='Task exception information.',
+    )
+    execution: Optional[ExecutionInfo] = Field(  # noqa: UP007
+        None,
+        description='Task execution information.',
+    )
 
-    task_id: str
-    function_name: str
-    parent_task_ids: list[str]
-    submit_time: float
-    received_time: float | None = None
-    success: bool | None = None
-    exception: ExceptionInfo | None = None
-    execution: ExecutionInfo | None = None
 
-
-@dataclasses.dataclass
 class TaskResult(Generic[T]):
     """Task result structure.
 
@@ -128,8 +159,9 @@ class TaskResult(Generic[T]):
         info: Task execution information.
     """
 
-    result: T
-    info: ExecutionInfo
+    def __init__(self, result: T, info: ExecutionInfo) -> None:
+        self.result = result
+        self.info = info
 
 
 class Task(Generic[P, T]):
@@ -193,4 +225,4 @@ class Task(Generic[P, T]):
             result_transform_start_time=result_transform_start_time,
             result_transform_end_time=result_transform_end_time,
         )
-        return TaskResult(result, info)
+        return TaskResult(result=result, info=info)

--- a/taps/executor/_protocol.py
+++ b/taps/executor/_protocol.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 from pydantic import ConfigDict
 
 
-class ExecutorConfig(BaseModel, abc.ABC):
+class ExecutorConfig(abc.ABC, BaseModel):
     """Abstract [`Executor`][concurrent.futures.Executor] plugin configuration."""  # noqa: E501
 
     name: str

--- a/taps/executor/dask.py
+++ b/taps/executor/dask.py
@@ -116,31 +116,24 @@ class DaskDistributedExecutor(Executor):
 
 @register('executor')
 class DaskDistributedConfig(ExecutorConfig):
-    """[`DaskDistributedExecutor`][taps.executor.dask.DaskDistributedExecutor] plugin configuration.
+    """[`DaskDistributedExecutor`][taps.executor.dask.DaskDistributedExecutor] plugin configuration."""  # noqa: E501
 
-    Attributes:
-        scheduler: Dask scheduler address.
-        use_threads: Use threads rather than processes for local clusters.
-        workers: Number of Dask workers for local clusters.
-        daemon_workers: Daemonize Dask workers.
-    """  # noqa: E501
-
-    name: Literal['dask'] = 'dask'
+    name: Literal['dask'] = Field('dask', description='Executor name.')
     scheduler: Optional[str] = Field(  # noqa: UP007
         None,
-        description='dask scheduler address',
+        description='Dask scheduler address.',
     )
     use_threads: bool = Field(
         False,
-        description='use threads instead of processes for dask workers',
+        description='Use threads instead of processes for dask workers.',
     )
     workers: Optional[int] = Field(  # noqa: UP007
         None,
-        description='maximum number of dask workers',
+        description='Maximum number of dask workers.',
     )
     daemon_workers: bool = Field(
         True,
-        description='configure if workers are daemon',
+        description='Configure if workers are daemon.',
     )
 
     def get_executor(self) -> DaskDistributedExecutor:

--- a/taps/executor/globus.py
+++ b/taps/executor/globus.py
@@ -12,18 +12,13 @@ from taps.plugins import register
 
 @register('executor')
 class GlobusComputeConfig(ExecutorConfig):
-    """Globus Compute [`Executor`][globus_compute_sdk.Executor] plugin configuration.
+    """Globus Compute [`Executor`][globus_compute_sdk.Executor] plugin configuration."""  # noqa: E501
 
-    Attributes:
-        endpoint: Globus Compute endpoint UUID.
-        batch_size: Maximum number of tasks to coalesce before submitting.
-    """  # noqa: E501
-
-    name: Literal['globus'] = 'globus'
-    endpoint: str = Field(description='endpoint UUID')
+    name: Literal['globus'] = Field('globus', description='Executor name.')
+    endpoint: str = Field(description='Globus Compute Endpoint UUID.')
     batch_size: int = Field(
         128,
-        description='maximum number of tasks to coalesce before submitting',
+        description='Maximum number of tasks to coalesce before submitting.',
     )
 
     def get_executor(self) -> FutureDependencyExecutor:

--- a/taps/executor/parsl.py
+++ b/taps/executor/parsl.py
@@ -38,20 +38,19 @@ class ParslLocalConfig(TapsExecutorConfig):
     Simple Parsl configuration that uses the
     [`HighThroughputExecutor`][parsl.executors.HighThroughputExecutor]
     on the local node.
-
-    Attributes:
-        workers: Maximum number of Parsl workers.
-        run_dir: Parsl run directory.
     """
 
-    name: Literal['parsl-local'] = 'parsl-local'
+    name: Literal['parsl-local'] = Field(
+        'parsl-local',
+        description='Executor name.',
+    )
     workers: Optional[int] = Field(  # noqa: UP007
         None,
-        description='max parsl workers',
+        description='Maximum number of parsl workers.',
     )
     run_dir: str = Field(
         'parsl-runinfo',
-        description='parsl run directory within the app run directory',
+        description='Parsl run directory within the app run directory.',
     )
 
     def get_executor(self) -> ParslPoolExecutor:
@@ -89,42 +88,36 @@ class ParslHTExConfig(TapsExecutorConfig):
 
     For simple, single-node HTEx deployments, prefer
     [`ParslLocalConfig`][taps.executor.parsl.ParslLocalConfig].
-
-    Attributes:
-        htex: HTEx configuration.
-        app_cache: Enable app caching.
-        retries: Number of retries in case of task failure.
-        strategy: Block scaling strategy.
-        max_idletime: Max idle time before strategy can shutdown unused blocks.
-        monitoring: Database monitoring configuration.
-        run_dir: Parsl run directory.
     """
 
-    name: Literal['parsl-htex'] = 'parsl-htex'
-    htex: HTExConfig = Field()
+    name: Literal['parsl-htex'] = Field(
+        'parsl-htex',
+        description='Executor name.',
+    )
+    htex: HTExConfig = Field(description='HTEx configuration.')
     app_cache: Optional[bool] = Field(  # noqa: UP007
         None,
-        description='enable app caching',
+        description='Enable app caching.',
     )
     retries: int = Field(
         0,
-        description='number of task retries in case of task failure',
+        description='Number of task retries in case of task failure.',
     )
     strategy: Optional[str] = Field(  # noqa: UP007
         None,
-        description='block scaling strategy',
+        description='Block scaling strategy.',
     )
     max_idletime: Optional[float] = Field(  # noqa: UP007
         None,
-        description='max idle time before strategy can shutdown unused blocks',
+        description='Idle time before strategy can shutdown unused blocks.',
     )
     monitoring: Optional[MonitoringConfig] = Field(  # noqa: UP007
         None,
-        description='database monitoring configuration',
+        description='Database monitoring configuration.',
     )
     run_dir: str = Field(
         'parsl-runinfo',
-        description='parsl run directory within the app run directory',
+        description='Parsl run directory within the app run directory.',
     )
 
     def get_executor(self) -> ParslPoolExecutor:
@@ -155,43 +148,36 @@ class HTExConfig(BaseModel):
         Extra options passed to this model will be provided as keyword
         arguments to
         [`parsl.executors.HighThroughputExecutor`][parsl.executors.HighThroughputExecutor].
-
-    Attributes:
-        provider: Configuration for the compute resource provider.
-        address: Address to connect to the main Parsl process.
-        manager_selector: Configuration for the manager selector (available
-            in Parsl v2024.8.5 and later).
-        worker_ports: Ports used by workers to connect to Parsl.
-        worker_port_range: Range of ports to choose worker ports from.
-        interchange_port_range: Ports used by Parsl to connect to the
-            interchange.
     """  # noqa: E501
 
     model_config = ConfigDict(extra='allow')
 
     provider: Optional[ProviderConfig] = Field(  # noqa: UP007
         None,
-        description='configuration for the compute resource provider',
+        description='Configuration for the compute resource provider.',
     )
     address: Optional[Union[str, AddressConfig]] = Field(  # noqa: UP007
         None,
-        description='address to connect to the main parsl process',
+        description='Address to connect to the main Parsl process.',
     )
     manager_selector: Optional[ManagerSelectorConfig] = Field(  # noqa: UP007
         None,
-        description='configuration for the manager selector',
+        description=(
+            'Configuration for the manager selector (available in '
+            'Parsl v2024.8.5 and later).'
+        ),
     )
     worker_ports: Optional[Tuple[int, int]] = Field(  # noqa: UP006,UP007
         None,
-        description='ports used by workers to connect to parsl',
+        description='Ports used by workers to connect to Parsl',
     )
     worker_port_range: Optional[Tuple[int, int]] = Field(  # noqa: UP006,UP007
         None,
-        description='range of ports to choose worker ports from',
+        description='Range of ports to choose worker ports from.',
     )
     interchange_port_range: Optional[Tuple[int, int]] = Field(  # noqa: UP006,UP007
         None,
-        description='ports used by parsl to connect to interchange',
+        description='Ports used by Parsl to connect to interchange.',
     )
 
     def get_executor(self) -> HighThroughputExecutor:
@@ -230,7 +216,7 @@ class AddressConfig(BaseModel):
 
     model_config = ConfigDict(extra='allow')
 
-    kind: str = Field(description='address function')
+    kind: str = Field(description='Function to invoke to get address.')
 
     @field_validator('kind')
     @classmethod
@@ -301,10 +287,10 @@ class ProviderConfig(BaseModel):
 
     model_config = ConfigDict(extra='allow')
 
-    kind: str = Field(description='name of execution provider')
+    kind: str = Field(description='Execution provider class name')
     launcher: Optional[LauncherConfig] = Field(  # noqa: UP007
         None,
-        description='provider launcher',
+        description='Launcher configuration.',
     )
 
     @field_validator('kind')
@@ -360,7 +346,7 @@ class LauncherConfig(BaseModel):
 
     model_config = ConfigDict(extra='allow')
 
-    kind: str = Field(description='name of provider launcher')
+    kind: str = Field(description='Launcher class name.')
 
     @field_validator('kind')
     @classmethod
@@ -407,7 +393,7 @@ class ManagerSelectorConfig(BaseModel):
 
     model_config = ConfigDict(extra='allow')
 
-    kind: str = Field(description='name of manager selector type')
+    kind: str = Field(description='Manager selector class name.')
 
     @field_validator('kind')
     @classmethod
@@ -479,11 +465,11 @@ class MonitoringConfig(BaseModel):
 
     hub_address: Optional[Union[str, AddressConfig]] = Field(  # noqa: UP007
         None,
-        description='address to connect to the monitoring hub',
+        description='Address to connect to the monitoring hub.',
     )
     hub_port_range: Optional[Tuple[int, int]] = Field(  # noqa: UP006,UP007
         None,
-        description='port range for a ZMQ channel from executor process',
+        description='Port range for a ZMQ channel from executor process.',
     )
 
     def get_monitoring(self) -> MonitoringHub:

--- a/taps/executor/python.py
+++ b/taps/executor/python.py
@@ -15,24 +15,22 @@ from taps.plugins import register
 
 @register('executor')
 class ProcessPoolConfig(ExecutorConfig):
-    """[`ProcessPoolExecutor`][concurrent.futures.ProcessPoolExecutor] plugin configuration.
+    """[`ProcessPoolExecutor`][concurrent.futures.ProcessPoolExecutor] plugin configuration."""  # noqa: E501
 
-    Attributes:
-        max_processes: Maximum number of processes.
-        context: Multiprocessing context type (fork, spawn, or forkserver).
-    """  # noqa: E501
-
-    name: Literal['process-pool'] = 'process-pool'
+    name: Literal['process-pool'] = Field(
+        'process-pool',
+        description='Executor name.',
+    )
     max_processes: int = Field(
         multiprocessing.cpu_count(),
-        description='maximum number of processes',
+        description='Maximum number of processes.',
     )
     context: Optional[  # noqa: UP007
         Literal['fork', 'spawn', 'forkserver']
     ] = Field(
         None,
         description=(
-            'multiprocessing start method (one of fork, spawn, or forkserver)'
+            'Multiprocessing start method (one of fork, spawn, or forkserver).'
         ),
     )
 
@@ -46,16 +44,15 @@ class ProcessPoolConfig(ExecutorConfig):
 
 @register('executor')
 class ThreadPoolConfig(ExecutorConfig):
-    """[`ThreadPoolExecutor`][concurrent.futures.ThreadPoolExecutor] plugin configuration.
+    """[`ThreadPoolExecutor`][concurrent.futures.ThreadPoolExecutor] plugin configuration."""  # noqa: E501
 
-    Attributes:
-        max_threads: Maximum number of threads.
-    """  # noqa: E501
-
-    name: Literal['thread-pool'] = 'thread-pool'
+    name: Literal['thread-pool'] = Field(
+        'thread-pool',
+        description='Executor name.',
+    )
     max_threads: int = Field(
         multiprocessing.cpu_count(),
-        description='maximum number of threads',
+        description='Maximum number of threads.',
     )
 
     def get_executor(self) -> FutureDependencyExecutor:

--- a/taps/executor/ray.py
+++ b/taps/executor/ray.py
@@ -128,23 +128,16 @@ class RayExecutor(Executor):
 
 @register('executor')
 class RayConfig(ExecutorConfig):
-    """[`RayExecutor`][taps.executor.ray.RayExecutor] plugin configuration.
+    """[`RayExecutor`][taps.executor.ray.RayExecutor] plugin configuration."""
 
-    Attributes:
-        address: Address of the Ray cluster to run on.
-        num_cpus: Number of actor processes to start in the pool. Defaults to
-            the number of cores in the Ray cluster, or the number of cores
-            on this machine.
-    """
-
-    name: Literal['ray'] = 'ray'
+    name: Literal['ray'] = Field('ray', description='Executor name.')
     address: Optional[str] = Field(  # noqa: UP007
         'local',
-        description='ray scheduler address (default spawns local cluster)',
+        description='Ray scheduler address (default spawns local cluster).',
     )
     num_cpus: Optional[int] = Field(  # noqa: UP007,
         None,
-        description='maximum number of CPUs that ray will use',
+        description='Maximum number of CPUs that ray will use.',
     )
 
     def get_executor(self) -> RayExecutor:

--- a/taps/filter/_object.py
+++ b/taps/filter/_object.py
@@ -64,12 +64,12 @@ class ObjectSizeFilterConfig(FilterConfig):
 
     name: Literal['object-size'] = Field(
         'object-size',
-        description='name of filter type',
+        description='Filter name.',
     )
-    min_size: int = Field(0, description='minimum object size in bytes')
+    min_size: int = Field(0, description='Minimum object size in bytes.')
     max_size: float = Field(
         math.inf,
-        description='maximum object size in bytes',
+        description='Maximum object size in bytes.',
     )
 
     def get_filter(self) -> Filter:
@@ -128,11 +128,11 @@ class ObjectTypeFilterConfig(FilterConfig):
 
     name: Literal['object-type'] = Field(
         'object-type',
-        description='name of filter type',
+        description='Filter name.',
     )
     patterns: Optional[List[str]] = Field(  # noqa: UP006,UP007
         None,
-        description='list of patterns to match against type names',
+        description='List of patterns to match against type names.',
     )
 
     def get_filter(self) -> Filter:
@@ -188,12 +188,12 @@ class PickleSizeFilterConfig(FilterConfig):
 
     name: Literal['pickle-size'] = Field(
         'pickle-size',
-        description='name of filter type',
+        description='Filter name.',
     )
-    min_size: int = Field(0, description='minimum object size in bytes')
+    min_size: int = Field(0, description='Minimum object size in bytes.')
     max_size: float = Field(
         math.inf,
-        description='maximum object size in bytes',
+        description='Maximum object size in bytes.',
     )
 
     def get_filter(self) -> Filter:

--- a/taps/filter/_protocol.py
+++ b/taps/filter/_protocol.py
@@ -27,7 +27,7 @@ class Filter(Protocol):
 class FilterConfig(BaseModel, abc.ABC):
     """Abstract [`Filter`][taps.filter.Filter] plugin configuration."""
 
-    name: str = Field(description='name of filter type')
+    name: str = Field(description='Filter name.')
 
     model_config: ConfigDict = ConfigDict(  # type: ignore[misc]
         extra='ignore',

--- a/taps/filter/_simple.py
+++ b/taps/filter/_simple.py
@@ -29,7 +29,7 @@ class AllFilter:
 class AllFilterConfig(FilterConfig):
     """[`AllFilter`][taps.filter.AllFilter] plugin configuration."""
 
-    name: Literal['all'] = Field('all', description='name of filter type')
+    name: Literal['all'] = Field('all', description='Filter name.')
 
     def get_filter(self) -> Filter:
         """Create a filter from the configuration."""
@@ -55,7 +55,7 @@ class NullFilter:
 class NullFilterConfig(FilterConfig):
     """[`NullFilter`][taps.filter.NullFilter] plugin configuration."""
 
-    name: Literal['null'] = Field('null', description='name of filter type')
+    name: Literal['null'] = Field('null', description='Filter name.')
 
     def get_filter(self) -> Filter:
         """Create a filter from the configuration."""

--- a/taps/logging.py
+++ b/taps/logging.py
@@ -35,10 +35,10 @@ def init_logging(
         ```
 
     Args:
-        logfile (str): option filepath to write log to.
-        level (int, str): minimum logging level.
-        logfile_level (int, str): minimum logging level for the logfile.
-        force (bool): remove any existing handlers attached to the root
+        logfile: Optional filepath to write log to.
+        level: Minimum logging level.
+        logfile_level: Minimum logging level for the logfile.
+        force: Remove any existing handlers attached to the root
             handler. This option is useful to silencing the third-party
             package logging. Note: should not be set when running inside
             pytest.

--- a/taps/run/config.py
+++ b/taps/run/config.py
@@ -31,63 +31,40 @@ from taps.run.utils import flatten_mapping
 
 
 class LoggingConfig(BaseModel):
-    """Logging configuration.
-
-    Attributes:
-        level: Logging level for `stdout`.
-        file_level: Logging level for the log file.
-        file_name: Logging file name. If `None`, only logging to `stdout`
-            is used.
-    """
+    """Logging configuration."""
 
     level: Union[int, str] = Field(  # noqa: UP007
         'INFO',
-        description='minimum logging level',
+        description='Minimum logging level for stdout.',
     )
     file_level: Union[int, str] = Field(  # noqa: UP007
         'INFO',
-        description='minimum logging level for the log file',
+        description='Minimum logging level for the log file.',
     )
     file_name: Optional[str] = Field(  # noqa: UP007
         'log.txt',
-        description='log file name',
+        description='Logging file name.',
     )
 
 
 class RunConfig(BaseModel):
-    """Run configuration.
-
-    Attributes:
-        dir_format: Run directory format.
-        env_vars: Dictionary mapping environment variables to values.
-            The environment variables will be set once the benchmark starts.
-    """
+    """Run configuration."""
 
     dir_format: str = Field(
         'runs/{name}_{executor}_{timestamp}',
         description=(
-            'run directory format (supports "{name}", "{timestamp}", and '
-            '"{executor}" for formatting)'
+            'Run directory format (supports "{name}", "{timestamp}", and '
+            '"{executor}" for formatting).'
         ),
     )
     env_vars: Dict[str, str] = Field(  # noqa: UP006
         default_factory=dict,
-        description='environment variables to set during benchmarking',
+        description='Environment variables to set during benchmarking.',
     )
 
 
 class Config(BaseSettings):
-    """Application benchmark configuration.
-
-    Attributes:
-        app: Application configuration.
-        engine: Engine configuration.
-        logging: Logging configuration.
-        run: Run configuration.
-        version: TaPS version used to create the config. Loading a config
-            with a version that does not match the current version will
-            log a warning that behavior could be different.
-    """
+    """Application benchmark configuration."""
 
     model_config = SettingsConfigDict(
         extra='forbid',
@@ -95,10 +72,19 @@ class Config(BaseSettings):
         validate_return=True,
     )
 
-    app: AppConfig = Field(description='application configuration')
-    engine: EngineConfig = Field(default_factory=EngineConfig)
-    logging: LoggingConfig = Field(default_factory=LoggingConfig)
-    run: RunConfig = Field(default_factory=RunConfig)
+    app: AppConfig = Field(description='Application configuration.')
+    engine: EngineConfig = Field(
+        default_factory=EngineConfig,
+        description='Engine configuration.',
+    )
+    logging: LoggingConfig = Field(
+        default_factory=LoggingConfig,
+        description='Logging configuration.',
+    )
+    run: RunConfig = Field(
+        default_factory=RunConfig,
+        description='Run configuration.',
+    )
     version: str = Field(
         taps.__version__,
         description='TaPS version (do not alter)',

--- a/taps/run/parse.py
+++ b/taps/run/parse.py
@@ -100,8 +100,8 @@ This behavior applies to all plugin types.
         default=argparse.SUPPRESS,
         nargs='+',
         help=(
-            'base toml configuration files to load '
-            '(file are parsed in order)'
+            'Base toml configuration files to load '
+            '(file are parsed in order).'
         ),
     )
 
@@ -111,7 +111,7 @@ This behavior applies to all plugin types.
         choices=list(get_app_configs().keys()),
         dest='app.name',
         metavar='APP',
-        help='app choice {%(choices)s}',
+        help='App choice {%(choices)s}.',
     )
 
     engine_group = parser.add_argument_group('engine options')
@@ -122,7 +122,7 @@ This behavior applies to all plugin types.
         default=argparse.SUPPRESS,
         dest='engine.executor.name',
         metavar='EXECUTOR',
-        help='executor choice {%(choices)s} (default: process-pool)',
+        help='Executor choice {%(choices)s}. (default: process-pool)',
     )
     engine_group.add_argument(
         '--engine.filter',
@@ -131,7 +131,7 @@ This behavior applies to all plugin types.
         default=argparse.SUPPRESS,
         dest='engine.filter.name',
         metavar='FILTER',
-        help='filter choice {%(choices)s} (default: all)',
+        help='Filter choice {%(choices)s}. (default: all)',
     )
     engine_group.add_argument(
         '--engine.transformer',
@@ -140,7 +140,7 @@ This behavior applies to all plugin types.
         default=argparse.SUPPRESS,
         dest='engine.transformer.name',
         metavar='TRANSFORMER',
-        help='transformer choice {%(choices)s} (default: null)',
+        help='Transformer choice {%(choices)s}. (default: null)',
     )
 
     if len(argv) == 0 or argv[0] in ['-h', '--help']:

--- a/taps/transformer/_file.py
+++ b/taps/transformer/_file.py
@@ -20,17 +20,13 @@ T = TypeVar('T')
 
 @register('transformer')
 class PickleFileTransformerConfig(TransformerConfig):
-    """[`PickleFileTransformer`][taps.transformer.PickleFileTransformer] plugin configuration.
-
-    Attributes:
-        file_dir: Object file directory.
-    """  # noqa: E501
+    """[`PickleFileTransformer`][taps.transformer.PickleFileTransformer] plugin configuration."""  # noqa: E501
 
     name: Literal['file'] = Field(
         'file',
-        description='name of transformer type',
+        description='Transformer name.',
     )
-    file_dir: str = Field(description='object file directory')
+    file_dir: str = Field(description='Object file directory.')
 
     def get_transformer(self) -> PickleFileTransformer:
         """Create a transformer from the configuration."""

--- a/taps/transformer/_null.py
+++ b/taps/transformer/_null.py
@@ -19,7 +19,7 @@ class NullTransformerConfig(TransformerConfig):
 
     name: Literal['null'] = Field(
         'null',
-        description='name of transformer type',
+        description='Transformer name.',
     )
 
     def get_transformer(self) -> NullTransformer:

--- a/taps/transformer/_protocol.py
+++ b/taps/transformer/_protocol.py
@@ -74,7 +74,7 @@ class Transformer(Protocol[IdentifierT]):
 class TransformerConfig(BaseModel, abc.ABC):
     """Abstract [`Transformer`][taps.transformer.Transformer] plugin configuration."""  # noqa: E501
 
-    name: str = Field(description='name of transformer type')
+    name: str = Field(description='Transformer name.')
 
     model_config: ConfigDict = ConfigDict(  # type: ignore[misc]
         extra='ignore',

--- a/taps/transformer/_proxy.py
+++ b/taps/transformer/_proxy.py
@@ -19,31 +19,25 @@ T = TypeVar('T')
 
 @register('transformer')
 class ProxyTransformerConfig(TransformerConfig):
-    """[`ProxyTransformer`][taps.transformer.ProxyTransformer] plugin configuration.
-
-    Attributes:
-        connector: Name of ProxyStore connector to use.
-        extract_target: See the usage in
-            [`ProxyTransformer`][taps.transformer.ProxyTransformer].
-    """  # noqa: E501
+    """[`ProxyTransformer`][taps.transformer.ProxyTransformer] plugin configuration."""  # noqa: E501
 
     name: Literal['proxystore'] = Field(
         'proxystore',
-        description='name of transformer type',
+        description='Transformer name.',
     )
     connector: ConnectorConfig = Field(
-        description='connector configuration',
+        description='Connector configuration.',
     )
     cache_size: int = Field(16, description='cache size')
     extract_target: bool = Field(
         False,
         description=(
-            'extract the target from the proxy when resolving the identifier'
+            'Extract the target from the proxy when resolving the identifier.'
         ),
     )
     populate_target: bool = Field(
         True,
-        description='populate target objects of newly created proxies',
+        description='Populate target objects of newly created proxies.',
     )
 
     def get_transformer(self) -> ProxyTransformer:

--- a/tests/apps/configs/fedlearn_test.py
+++ b/tests/apps/configs/fedlearn_test.py
@@ -11,6 +11,7 @@ def test_create_app() -> None:
         sys.modules,
         {'taps.apps.fedlearn.types': mock.MagicMock()},
     ):
+        FedlearnConfig(dataset='MNIST')
         config = FedlearnConfig()
 
         with mock.patch.dict(

--- a/tests/apps/configs/synthetic_test.py
+++ b/tests/apps/configs/synthetic_test.py
@@ -4,10 +4,14 @@ import pytest
 from pydantic import ValidationError
 
 from taps.apps.configs.synthetic import SyntheticConfig
+from taps.apps.configs.synthetic import WorkflowStructure
 
 
 def test_create_app() -> None:
-    config = SyntheticConfig(structure='sequential', task_count=3)
+    config = SyntheticConfig(
+        structure=WorkflowStructure.SEQUENTIAL,
+        task_count=3,
+    )
     assert config.get_app()
 
 

--- a/tests/apps/configs/synthetic_test.py
+++ b/tests/apps/configs/synthetic_test.py
@@ -11,14 +11,6 @@ def test_create_app() -> None:
     assert config.get_app()
 
 
-def test_validate_base_app() -> None:
-    with pytest.raises(
-        ValidationError,
-        match="Specified structure 'fake' is unknown.",
-    ):
-        SyntheticConfig(structure='fake', task_count=3)
-
-
 def test_validate_rate() -> None:
     with pytest.raises(
         ValidationError,

--- a/tests/engine/engine_test.py
+++ b/tests/engine/engine_test.py
@@ -25,7 +25,12 @@ def test_task_future_exception() -> None:
 
     task = TaskFuture(
         future,
-        TaskInfo('test', 'test', [], 0),
+        TaskInfo(
+            task_id='test',
+            function_name='test',
+            parent_task_ids=[],
+            submit_time=0,
+        ),
         TaskTransformer(NullTransformer(), NullFilter()),
     )
 
@@ -155,12 +160,22 @@ def test_wait() -> None:
 
     fast_task = TaskFuture(
         fast_future,
-        TaskInfo('fast-id', 'fast', [], 0),
+        TaskInfo(
+            task_id='fast-id',
+            function_name='fast',
+            parent_task_ids=[],
+            submit_time=0,
+        ),
         TaskTransformer(NullTransformer(), NullFilter()),
     )
     slow_task = TaskFuture(
         slow_future,
-        TaskInfo('slow-id', 'slow', [], 0),
+        TaskInfo(
+            task_id='slow-id',
+            function_name='slow',
+            parent_task_ids=[],
+            submit_time=0,
+        ),
         TaskTransformer(NullTransformer(), NullFilter()),
     )
 


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

This changes the docs to use `griffe-fieldz` to automatically inject the field descriptions of `BaseModel`s into the docstring information. This means that field descriptions do not need to be duplicated.

Note that the plugin did not work well with dataclasses so I changed the types of the dataclasses in `taps.engine.task`.

### Fixes
<!--- List any issue numbers above that this PR addresses --->
<!--- Otherwise, write N/A --->

- Fixes #120 

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [x] Internal (refactoring, performance, and testing)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (no changes to the code)
- [ ] Development (CI workflows, packages, templates, etc.)
- [ ] Package (package dependencies and versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Documentation correctly populates parameters of `Config`s.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, documentation, enhancement, package, etc.).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
