### PR TITLE
Add `wait_for_workers` flag in Dask Distributed config and executor (#131)

### DIFF
--- a/tests/executor/dask_test.py
+++ b/tests/executor/dask_test.py
@@ -43,7 +43,7 @@ def test_map_function(local_client: Client) -> None:
     'config',
     (
         DaskDistributedConfig(scheduler='localhost'),
-        DaskDistributedConfig(workers=1, use_threads=True),
+        DaskDistributedConfig(workers=1, use_threads=True, wait_for_workers=1),
     ),
 )
 def test_config_get_executor(config: DaskDistributedConfig) -> None:


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Add `wait_for_workers` flag in Dask Distributed config and executor. This is helpful when the client is connected to a remote scheduler and you want to wait to submit work until the workers are connected to the scheduler.

### Fixes
<!--- List any issue numbers above that this PR addresses --->
<!--- Otherwise, write N/A --->

- Fixes #131

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Internal (refactoring, performance, and testing)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (no changes to the code)
- [ ] Development (CI workflows, packages, templates, etc.)
- [ ] Package (package dependencies and versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Added tests for coverage and tested with the cholesky app.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, documentation, enhancement, package, etc.).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
