### PR TITLE
Forbid extra fields in engine plugin config types

### DIFF
--- a/taps/executor/_protocol.py
+++ b/taps/executor/_protocol.py
@@ -13,7 +13,7 @@ class ExecutorConfig(abc.ABC, BaseModel):
     name: str
 
     model_config: ConfigDict = ConfigDict(  # type: ignore[misc]
-        extra='ignore',
+        extra='forbid',
         validate_default=True,
         validate_return=True,
     )

--- a/taps/executor/parsl.py
+++ b/taps/executor/parsl.py
@@ -90,6 +90,8 @@ class ParslHTExConfig(TapsExecutorConfig):
     [`ParslLocalConfig`][taps.executor.parsl.ParslLocalConfig].
     """
 
+    model_config = ConfigDict(extra='allow')  # type: ignore[misc]
+
     name: Literal['parsl-htex'] = Field(
         'parsl-htex',
         description='Executor name.',

--- a/taps/filter/_protocol.py
+++ b/taps/filter/_protocol.py
@@ -30,7 +30,7 @@ class FilterConfig(BaseModel, abc.ABC):
     name: str = Field(description='Filter name.')
 
     model_config: ConfigDict = ConfigDict(  # type: ignore[misc]
-        extra='ignore',
+        extra='forbid',
         validate_default=True,
         validate_return=True,
     )

--- a/taps/transformer/_protocol.py
+++ b/taps/transformer/_protocol.py
@@ -77,7 +77,7 @@ class TransformerConfig(BaseModel, abc.ABC):
     name: str = Field(description='Transformer name.')
 
     model_config: ConfigDict = ConfigDict(  # type: ignore[misc]
-        extra='ignore',
+        extra='forbid',
         validate_default=True,
         validate_return=True,
     )

--- a/tests/executor/parsl_test.py
+++ b/tests/executor/parsl_test.py
@@ -76,7 +76,6 @@ def test_get_htex_executor(tmp_path: pathlib.Path, mock_monitoring) -> None:
         app_cache=False,
         retries=1,
         run_dir=str(tmp_path / 'parsl'),
-        max_workers_per_node=4,
         monitoring=MonitoringConfig(
             hub_address='localhost',
             logging_endpoint=f'sqlite:///{tmp_path}/monitoring.db',


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

This is a revert of df1be9fe6b6864645a7285a892578d0ad2f19927. The justification there to ignore extra fields is overriding the plugin kind in a config file from the CLI args. This is a nice feature, but it comes at the risk of not catching typos in config field names. I think it's ultimately better to be overly strict at the cost of some flexibility over letting simple and subtle errors in a config sneak in.

### Fixes
<!--- List any issue numbers above that this PR addresses --->
<!--- Otherwise, write N/A --->

- Fixes #124

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Internal (refactoring, performance, and testing)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (no changes to the code)
- [ ] Development (CI workflows, packages, templates, etc.)
- [ ] Package (package dependencies and versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, documentation, enhancement, package, etc.).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
