### PR TITLE
Fix not fully defined pydantic model `Client` of fedlearn app

### DIFF
--- a/taps/apps/fedlearn/app.py
+++ b/taps/apps/fedlearn/app.py
@@ -6,6 +6,8 @@ import pathlib
 import numpy
 import torch
 
+from taps.apps.fedlearn.client import create_clients
+from taps.apps.fedlearn.client import unweighted_module_avg
 from taps.apps.fedlearn.modules import create_model
 from taps.apps.fedlearn.modules import load_data
 from taps.apps.fedlearn.tasks import local_train
@@ -13,8 +15,6 @@ from taps.apps.fedlearn.tasks import no_local_train
 from taps.apps.fedlearn.tasks import test_model
 from taps.apps.fedlearn.types import DataChoices
 from taps.apps.fedlearn.types import Result
-from taps.apps.fedlearn.utils import create_clients
-from taps.apps.fedlearn.utils import unweighted_module_avg
 from taps.engine import as_completed
 from taps.engine import Engine
 from taps.engine import TaskFuture

--- a/taps/apps/fedlearn/tasks.py
+++ b/taps/apps/fedlearn/tasks.py
@@ -6,7 +6,7 @@ from torch.nn import functional as F  # noqa: N812
 from torch.utils.data import DataLoader
 from torch.utils.data import Dataset
 
-from taps.apps.fedlearn.types import Client
+from taps.apps.fedlearn.client import Client
 from taps.apps.fedlearn.types import Result
 from taps.engine import task
 

--- a/taps/apps/fedlearn/types.py
+++ b/taps/apps/fedlearn/types.py
@@ -4,24 +4,12 @@ import enum
 import sys
 from typing import Any
 from typing import Dict
-from typing import Optional
-from typing import TYPE_CHECKING
 
 if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
     from typing import TypeAlias
 else:  # pragma: <3.10 cover
     from typing_extensions import TypeAlias
 
-from pydantic import BaseModel
-from pydantic import ConfigDict
-from pydantic import Field
-
-if TYPE_CHECKING:
-    from torch import nn
-    from torch.utils.data import Subset
-
-ClientID: TypeAlias = int
-"""Integer IDs for `Client` instances."""
 
 Result: TypeAlias = Dict[str, Any]
 """Result type for each FL epoch, round, and task."""
@@ -38,18 +26,3 @@ class DataChoices(enum.Enum):
     """FMNIST dataset."""
     MNIST = 'mnist'
     """MNIST dataset."""
-
-
-class Client(BaseModel):
-    """Client class."""
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    idx: ClientID = Field(description='Client ID')
-    """Client ID."""
-    model: nn.Module = Field(description="Client's local model")
-    """Client's local model."""
-    data: Optional[Subset] = Field(  # noqa: UP007
-        description='The subset of data this client will train on.',
-    )
-    """The subset of data this client will train on."""


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

I think I accidentally introduced this error when trying to make `DataChoices` importable without requiring `torch` to be installed. But this meant the types of the `Client` model for pydantic were only available at type checking time (not runtime).

### Fixes
<!--- List any issue numbers above that this PR addresses --->
<!--- Otherwise, write N/A --->

- Fixes #152

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Internal (refactoring, performance, and testing)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (no changes to the code)
- [ ] Development (CI workflows, packages, templates, etc.)
- [ ] Package (package dependencies and versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Ran the example in the docs.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, documentation, enhancement, package, etc.).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
