### PR TITLE
Add warning to failures app guide about dill version incompatibility

### DIFF
--- a/docs/apps/docking.md
+++ b/docs/apps/docking.md
@@ -70,6 +70,6 @@ For example, the `--app.batch-size` and `--app.num-iterations` parameters contro
     You may need to install `libsqlite` yourself and/or set `LD_LIBRARY_PATH` to prefer the right version.
     If you are following the installation instructions here, we found the following to work.
     ```bash
-    conda install libsqlite<3.46.0
+    conda install "libsqlite<3.46.0"
     ```
     See [Issue #151](https://github.com/proxystore/taps/issues/151){target=_blank} for further discussion and debugging tips.

--- a/docs/apps/failures.md
+++ b/docs/apps/failures.md
@@ -24,6 +24,16 @@ For example, to use `failures` with the `cholesky` application, install TaPS usi
 pip install -e .[cholesky]
 ```
 
+!!! warning
+
+    The `failures` app is not compatible with `dill==0.3.6` which, as of writing, is the pinned version installed by `globus-compute-sdk`.
+    To use the `failures` app, manually upgrade `dill`:
+    ```bash
+    pip install --upgrade dill==0.3.8
+    ```
+    It is still possible to use Globus Compute with newer `dill` versions but you must ensure the same version of `dill` is installed on all endpoints.
+    See [Issue #155](https://github.com/proxystore/taps/issues/155){target=_blank} for more information.
+
 ## Data
 
 Data requirements depend on the base application that failures are injected into.

--- a/taps/apps/configs/moldesign.py
+++ b/taps/apps/configs/moldesign.py
@@ -4,6 +4,7 @@ import pathlib
 from typing import Literal
 
 from pydantic import Field
+from pydantic import field_validator
 
 from taps.apps import App
 from taps.apps import AppConfig
@@ -34,6 +35,17 @@ class MoldesignConfig(AppConfig):
         ),
     )
     seed: int = Field(0, description='Random seed.')
+
+    @field_validator('initial_count')
+    @classmethod
+    def _validate_initial_count(cls, value: int) -> int:
+        if value < 4:  # noqa: PLR2004
+            # This is becauser the KNeighborsRegressor used by the app is
+            # configured to use n_neighbors=4 and n_samples >= n_neighbors.
+            raise ValueError(
+                'Number of initial calculations must be at least four.',
+            )
+        return value
 
     def get_app(self) -> App:
         """Create an application instance from the config."""

--- a/tests/apps/configs/docking_test.py
+++ b/tests/apps/configs/docking_test.py
@@ -4,6 +4,9 @@ import pathlib
 import sys
 from unittest import mock
 
+import pytest
+from pydantic import ValidationError
+
 from taps.apps.configs.docking import DockingConfig
 
 
@@ -19,3 +22,16 @@ def test_create_app(tmp_path: pathlib.Path) -> None:
         {'taps.apps.docking.app': mock.MagicMock()},
     ):
         config.get_app()
+
+
+def test_validate_config(tmp_path: pathlib.Path) -> None:
+    with pytest.raises(
+        ValidationError,
+        match='Number of initial simulations',
+    ):
+        DockingConfig(
+            smi_file_name_ligand=tmp_path / 'test',
+            receptor=tmp_path / 'receptor',
+            tcl_path=tmp_path / 'test',
+            initial_simulations=1,
+        )

--- a/tests/apps/configs/moldesign_test.py
+++ b/tests/apps/configs/moldesign_test.py
@@ -4,6 +4,9 @@ import pathlib
 import sys
 from unittest import mock
 
+import pytest
+from pydantic import ValidationError
+
 from taps.apps.configs.moldesign import MoldesignConfig
 
 
@@ -15,3 +18,11 @@ def test_create_app(tmp_path: pathlib.Path) -> None:
         {'taps.apps.moldesign.app': mock.MagicMock()},
     ):
         config.get_app()
+
+
+def test_validate_config(tmp_path: pathlib.Path) -> None:
+    with pytest.raises(
+        ValidationError,
+        match='Number of initial calculations',
+    ):
+        MoldesignConfig(dataset=tmp_path, initial_count=1)


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Add warning to failures app guide about dill version incompatibility.

Also, while debugging, I noticed that we should validate docking/moldesign for the min number of initial simulations.

Related to #155, but this doesn't really "fix" that issue.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->
<!--- Otherwise, write N/A --->

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Internal (refactoring, performance, and testing)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (no changes to the code)
- [ ] Development (CI workflows, packages, templates, etc.)
- [ ] Package (package dependencies and versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, documentation, enhancement, package, etc.).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
