### PR TITLE
Fill dill serialization of tasks when using the `failures` app

### DIFF
--- a/docs/apps/failures.md
+++ b/docs/apps/failures.md
@@ -26,13 +26,13 @@ pip install -e .[cholesky]
 
 !!! warning
 
-    The `failures` app is not compatible with `dill==0.3.6` which, as of writing, is the pinned version installed by `globus-compute-sdk`.
-    To use the `failures` app, manually upgrade `dill`:
+    In older versions of TaPS, the `failures` app was not compatible with `dill==0.3.6` which, as of writing, is the pinned version installed by `globus-compute-sdk`.
+    If you encounter serialization issues with Globus Compute/Parsl when using the `failures` app, manually upgrade `dill`:
     ```bash
     pip install --upgrade dill==0.3.8
     ```
     It is still possible to use Globus Compute with newer `dill` versions but you must ensure the same version of `dill` is installed on all endpoints.
-    See [Issue #155](https://github.com/proxystore/taps/issues/155){target=_blank} for more information.
+    See [Issue #155](https://github.com/proxystore/taps/issues/155){target=_blank} for more information and [PR #163](https://github.com/proxystore/taps/pull/163){target=_blank} which addresses this issue.
 
 ## Data
 

--- a/taps/engine/_engine.py
+++ b/taps/engine/_engine.py
@@ -208,14 +208,18 @@ class Engine:
             task_future.info.success = True
             task_future.info.execution = execution_info
         task_future.info.received_time = time.time()
-        self.record_logger.log(task_future.info.model_dump())
+        self.record_logger.log(task_future.info.asdict())
 
     def _get_task(self, function: Callable[P, R]) -> Task[P, R]:
         if isinstance(function, Task):
             return function
 
         if function not in self._registered_tasks:
-            self._registered_tasks[function] = task(function)
+            function_as_task = task(function)
+            logger.debug(
+                f'Created task from function (name={function_as_task.name})',
+            )
+            self._registered_tasks[function] = function_as_task
 
         return cast(Task[P, R], self._registered_tasks[function])
 

--- a/taps/engine/task.py
+++ b/taps/engine/task.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import dataclasses
 import functools
 import socket
 import sys
 import time
+from dataclasses import field
 from typing import Any
 from typing import Callable
 from typing import Generic
@@ -19,24 +21,23 @@ if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
 else:  # pragma: <3.10 cover
     from typing_extensions import ParamSpec
 
-from pydantic import BaseModel
-from pydantic import Field
-
 from taps.engine.transform import TaskTransformer
 
 P = ParamSpec('P')
 R = TypeVar('R')
 
 
-class ExceptionInfo(BaseModel):
+@dataclasses.dataclass(frozen=True)
+class ExceptionInfo:
     """Task exception information."""
 
-    type: str = Field(description='Exception type.')
-    message: str = Field(description='Exception message.')
-    traceback: str = Field(description='Exception traceback.')
+    type: str = field(metadata={'description': 'Exception type.'})
+    message: str = field(metadata={'description': 'Exception message.'})
+    traceback: str = field(metadata={'description': 'Exception traceback.'})
 
 
-class ExecutionInfo(BaseModel):
+@dataclasses.dataclass(frozen=True)
+class ExecutionInfo:
     """Task execution information.
 
     All times are Unix timestamps recorded on the worker process executing
@@ -58,105 +59,142 @@ class ExecutionInfo(BaseModel):
     ```
     """
 
-    hostname: str = Field(
-        description='Name of the host the task was executed on.',
+    hostname: str = field(
+        metadata={'description': 'Name of the host the task was executed on.'},
     )
-    execution_start_time: float = Field(
-        description=(
-            'Unix timestamp indicating the task began execution on a worker.'
-        ),
+    execution_start_time: float = field(
+        metadata={
+            'description': (
+                'Unix timestamp indicating the task began execution on a '
+                'worker.'
+            ),
+        },
     )
-    execution_end_time: float = Field(
-        description=(
-            'Unix timestamp indicating the task finished execution '
-            'on a worker.'
-        ),
+    execution_end_time: float = field(
+        metadata={
+            'description': (
+                'Unix timestamp indicating the task finished execution '
+                'on a worker.'
+            ),
+        },
     )
-    task_start_time: float = Field(
-        description=(
-            'Unix timestamp indicating the start of execution of '
-            'the task function.'
-        ),
+    task_start_time: float = field(
+        metadata={
+            'description': (
+                'Unix timestamp indicating the start of execution of '
+                'the task function.'
+            ),
+        },
     )
-    task_end_time: float = Field(
-        description=(
-            'Unix timestamp indicating the end of execution of '
-            'the task function.'
-        ),
+    task_end_time: float = field(
+        metadata={
+            'description': (
+                'Unix timestamp indicating the end of execution of '
+                'the task function.'
+            ),
+        },
     )
-    input_transform_start_time: float = Field(
-        description=(
-            'Unix timestamp indicating the start of resolving input '
-            'arguments on the worker.'
-        ),
+    input_transform_start_time: float = field(
+        metadata={
+            'description': (
+                'Unix timestamp indicating the start of resolving input '
+                'arguments on the worker.'
+            ),
+        },
     )
-    input_transform_end_time: float = Field(
-        description=(
-            'Unix timestamp indicating the end of resolving input '
-            'arguments on the worker.'
-        ),
+    input_transform_end_time: float = field(
+        metadata={
+            'description': (
+                'Unix timestamp indicating the end of resolving input '
+                'arguments on the worker.'
+            ),
+        },
     )
-    result_transform_start_time: float = Field(
-        description=(
-            'Unix timestamp indicating the start of transforming the '
-            'task function result on the worker.'
-        ),
+    result_transform_start_time: float = field(
+        metadata={
+            'description': (
+                'Unix timestamp indicating the start of transforming the '
+                'task function result on the worker.'
+            ),
+        },
     )
-    result_transform_end_time: float = Field(
-        description=(
-            'Unix timestamp indicating the end of transforming the '
-            'task function result on the worker.'
-        ),
+    result_transform_end_time: float = field(
+        metadata={
+            'description': (
+                'Unix timestamp indicating the end of transforming the '
+                'task function result on the worker.'
+            ),
+        },
     )
 
 
-class TaskInfo(BaseModel):
+@dataclasses.dataclass()
+class TaskInfo:
     """Task execution information."""
 
-    task_id: str = Field(
-        description='Unique UUID of the task as determined by the engine.',
+    task_id: str = field(
+        metadata={
+            'description': (
+                'Unique UUID of the task as determined by the engine.'
+            ),
+        },
     )
-    name: str = Field(
-        description=(
-            'Name of the task. Typically defaults to the name of the '
-            'function unless overridden.'
-        ),
+    name: str = field(
+        metadata={
+            'description': (
+                'Name of the task. Typically defaults to the name of the '
+                'function unless overridden.'
+            ),
+        },
     )
-    parent_task_ids: List[str] = Field(  # noqa: UP006
-        description=(
-            'UUIDs of parent tasks. A task is a child task if its arguments '
-            'contain a future to the result of another task.'
-        ),
+    parent_task_ids: List[str] = field(  # noqa: UP006
+        metadata={
+            'description': (
+                'UUIDs of parent tasks. A task is a child task if its '
+                'arguments contain a future to the result of another task.'
+            ),
+        },
     )
-    submit_time: float = Field(
-        description=(
-            'Unix timestamp indicating the engine submitted the task '
-            'to the executor.'
-        ),
+    submit_time: float = field(
+        metadata={
+            'description': (
+                'Unix timestamp indicating the engine submitted the task '
+                'to the executor.'
+            ),
+        },
     )
-    received_time: Optional[float] = Field(  # noqa: UP007
-        None,
-        description=(
-            'Unix timestamp indicating the executor was notified the task '
-            'has completed. This is recorded in a callback on the task future '
-            'and thus includes any lag in invoking the future callbacks.'
-        ),
+    received_time: Optional[float] = field(  # noqa: UP007
+        default=None,
+        metadata={
+            'description': (
+                'Unix timestamp indicating the executor was notified the task '
+                'has completed. This is recorded in a callback on the task '
+                'future and thus includes any lag in invoking the future '
+                'callbacks.'
+            ),
+        },
     )
-    success: Optional[bool] = Field(  # noqa: UP007
-        None,
-        description=(
-            'Boolean indicating if the task completed without raising '
-            'an exception.'
-        ),
+    success: Optional[bool] = field(  # noqa: UP007
+        default=None,
+        metadata={
+            'description': (
+                'Boolean indicating if the task completed without raising '
+                'an exception.'
+            ),
+        },
     )
-    exception: Optional[ExceptionInfo] = Field(  # noqa: UP007
-        None,
-        description='Task exception information.',
+    exception: Optional[ExceptionInfo] = field(  # noqa: UP007
+        default=None,
+        metadata={'description': 'Task exception information.'},
     )
-    execution: Optional[ExecutionInfo] = Field(  # noqa: UP007
-        None,
-        description='Task execution information.',
+    execution: Optional[ExecutionInfo] = field(  # noqa: UP007
+        default=None,
+        metadata={'description': 'Task execution information.'},
     )
+
+    def asdict(self) -> dict[str, Any]:
+        """Get task info as a dictionary."""
+        return dataclasses.asdict(self)
 
 
 class TaskResult(Generic[R]):


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

This is related to https://github.com/proxystore/taps/issues/155 which reported errors when dill attempted to serialize the closure task wrappers for failure task injection. These closures were serialized by value which caused issues with type annotations containing pydantic models which use ABCs, and dill 0.3.6, required by Globus Compute, can't pickle ABCs.

This PR addresses two aspects of this problem:
- Task data structures were reverted from pydantic `BaseModel`s to dataclasses. This reverts #137.
- Closures are no longer used to wrap tasks in the failure app.

I also caught a bug in how `_dependency_failure_parent_task` was called. It was used like a task factory, but was incorrectly wrapped in the `@task` decorator.

### Fixes
<!--- List any issue numbers above that this PR addresses --->
<!--- Otherwise, write N/A --->

- Fixes #155 

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Internal (refactoring, performance, and testing)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (no changes to the code)
- [ ] Development (CI workflows, packages, templates, etc.)
- [ ] Package (package dependencies and versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Tested the cholesky app alone and with failure injection using Dask, Process Pool, Ray, and Parsl. I also tested the failure modes for dependency and import which have different task wrappers.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, documentation, enhancement, package, etc.).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
