### PR TITLE
Enable metric recording metrics when using `ProxyTransformer`

### DIFF
--- a/taps/transformer/_proxy.py
+++ b/taps/transformer/_proxy.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+import dataclasses
+import json
+import pathlib
 import sys
 from typing import Any
+from typing import cast
+from typing import Dict
 from typing import Literal
 from typing import TypeVar
+from typing import Union
 
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     from typing import Self
@@ -24,6 +30,10 @@ from taps.plugins import register
 from taps.transformer._protocol import TransformerConfig
 
 T = TypeVar('T')
+JSON = Union[int, float, str, Dict[str, 'JSON']]
+_PROXYSTORE_DIR = 'proxystore'
+_PROXYSTORE_AGGREGATE_FILE = 'aggregated.json'
+_PROXYSTORE_STATS_FILE = 'stats.jsonl'
 
 
 @register('transformer')
@@ -99,6 +109,7 @@ class ProxyTransformerConfig(TransformerConfig):
             ),
             async_resolve=self.async_resolve,
             extract_target=self.extract_target,
+            metrics_dir=_PROXYSTORE_DIR if self.metrics else None,
         )
 
 
@@ -116,6 +127,12 @@ class ProxyTransformer:
             will return the target object. Otherwise, the proxy is returned
             since a proxy can act as the target object. Not compatible
             with `async_resolve=True`.
+        metrics_dir: If metrics recording on `store` is `True`, then
+            write the recorded metrics to this directory when this transformer
+            is closed. Typically, `close()` is only called on the transformer
+            instance in the main TaPS process (i.e., `close()` is not called
+            in worker processes) so only the metrics from the main process
+            will be recorded.
     """
 
     def __init__(
@@ -124,6 +141,7 @@ class ProxyTransformer:
         *,
         async_resolve: bool = False,
         extract_target: bool = False,
+        metrics_dir: str | None = None,
     ) -> None:
         if async_resolve and extract_target:
             raise ValueError(
@@ -134,19 +152,26 @@ class ProxyTransformer:
         self.store = store
         self.async_resolve = async_resolve
         self.extract_target = extract_target
+        self.metrics_dir = (
+            pathlib.Path(metrics_dir).resolve()
+            if metrics_dir is not None
+            else None
+        )
 
     def __repr__(self) -> str:
         ctype = type(self).__name__
         store = f'store={self.store}'
         async_ = f'async_resolve={self.async_resolve}'
         extract = f'extract_target={self.extract_target}'
-        return f'{ctype}({store}, {async_}, {extract})'
+        metrics = f'metrics_dir={self.metrics_dir}'
+        return f'{ctype}({store}, {async_}, {extract}, {metrics})'
 
     def __getstate__(self) -> dict[str, Any]:
         return {
             'config': self.store.config(),
             'async_resolve': self.async_resolve,
             'extract_target': self.extract_target,
+            'metrics_dir': self.metrics_dir,
         }
 
     def __setstate__(self, state: dict[str, Any]) -> None:
@@ -157,10 +182,18 @@ class ProxyTransformer:
             self.store = Store.from_config(state['config'])
         self.async_resolve = state['async_resolve']
         self.extract_target = state['extract_target']
+        self.metrics_dir = state['metrics_dir']
 
     def close(self) -> None:
         """Close the transformer."""
         self.store.close()
+
+        if self.metrics_dir is not None:
+            _write_metrics(
+                self.store,
+                self.metrics_dir / _PROXYSTORE_AGGREGATE_FILE,
+                self.metrics_dir / _PROXYSTORE_STATS_FILE,
+            )
 
     def is_identifier(self, obj: Any) -> bool:
         """Check if the object is an identifier instance."""
@@ -192,3 +225,44 @@ class ProxyTransformer:
         if self.async_resolve:
             resolve_async(identifier)
         return identifier
+
+
+def _format_metrics(
+    store: Store[Any],
+) -> tuple[dict[str, JSON], list[JSON]] | None:
+    if store.metrics is None:
+        return None
+
+    aggregated = {
+        key: cast(JSON, dataclasses.asdict(times))
+        for key, times in store.metrics.aggregate_times().items()
+    }
+
+    metrics = store.metrics._metrics.values()
+    jsonified = map(dataclasses.asdict, metrics)
+
+    return aggregated, list(jsonified)
+
+
+def _write_metrics(
+    store: Store[Any],
+    aggregated_path: pathlib.Path,
+    stats_path: pathlib.Path,
+) -> None:
+    metrics = _format_metrics(store)
+    if metrics is None:
+        return
+
+    aggregated, individual = metrics
+    if len(individual) == 0:
+        return
+
+    aggregated_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(aggregated_path, 'w') as f:
+        json.dump(aggregated, f, indent=4)
+
+    stats_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(stats_path, 'a') as f:
+        for stats in individual:
+            json.dump(stats, f)
+            f.write('\n')

--- a/tests/transformer/proxy_test.py
+++ b/tests/transformer/proxy_test.py
@@ -27,6 +27,19 @@ def test_file_config(tmp_path: pathlib.Path) -> None:
     transformer.close()
 
 
+def test_file_config_extras(tmp_path: pathlib.Path) -> None:
+    config = ProxyTransformerConfig(
+        connector=ConnectorConfig(
+            kind='file',
+            options={'store_dir': str(tmp_path)},
+        ),
+        metrics=True,
+        register=False,
+    )
+    transformer = config.get_transformer()
+    transformer.close()
+
+
 def test_config_validation_error(tmp_path: pathlib.Path) -> None:
     with pytest.raises(
         ValidationError,


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Setting `engine.transformer.metrics true` will now enable metric recording on the `Store` used by a `ProxyTransformer`. The recorded metrics are written to the `proxystore/` sub-directory within the `run_dir` of a benchmark. The `proxystore/` directory will contain two file if metrics were recorded:
* `aggregated.json`: aggregated statistics for different store operations
* `stats.jsonl`: a line-delimited JSON file where each line corresponds to the stats for a unique object that was proxied

**Note:** the recorded stats only reflect the performance metrics as seen by the main TaPS process. In other words, the performance stats recorded on workers are not recorded.

To learn more about metrics in ProxyStore, see the [guide](https://docs.proxystore.dev/main/guides/performance/).

### Fixes
<!--- List any issue numbers above that this PR addresses --->
<!--- Otherwise, write N/A --->

- Fixes #182

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Internal (refactoring, performance, and testing)
- [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (no changes to the code)
- [ ] Development (CI workflows, packages, templates, etc.)
- [ ] Package (package dependencies and versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Added unit tests and validated with the following command
```
python -m taps.run --app cholesky --app.block-size 100 --app.matrix-size 200 --engine.transformer proxystore --engine.transformer.connector.kind file --engine.transformer.connector.options '{"store_dir": "./object-cache"}' --engine.transformer.metrics true
```

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, documentation, enhancement, package, etc.).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
