### PR TITLE
Add dynamic warmup of executor and include as option for Parsl

### DIFF
--- a/taps/executor/parsl.py
+++ b/taps/executor/parsl.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     )
 
 from taps.executor import ExecutorConfig as TapsExecutorConfig
+from taps.executor.utils import warmup_executor
 from taps.plugins import register
 
 
@@ -122,11 +123,40 @@ class ParslHTExConfig(TapsExecutorConfig):
         'parsl-runinfo',
         description='Parsl run directory within the app run directory.',
     )
+    warmup: bool = Field(
+        False,
+        description='Warmup parsl workers on initialization of executor.',
+    )
+    min_connected_nodes: int = Field(
+        1,
+        description='Number of nodes necessary to consider parsl warm.',
+    )
+    warmup_batch_size: int = Field(
+        1,
+        description='Number of tasks to submit per warmup batch.',
+    )
+    max_warmup_batches: int = Field(
+        1,
+        description='Maximum number of warm up batches before failure.',
+    )
+    warmup_sleep: int = Field(
+        1,
+        description='Time to sleep between warmup batches.',
+    )
 
     def get_executor(self) -> ParslPoolExecutor:
         """Create an executor instance from the config."""
         options = self.model_dump(
-            exclude={'name', 'htex', 'monitoring'},
+            exclude={
+                'name',
+                'htex',
+                'monitoring',
+                'warmup',
+                'min_connected_nodes',
+                'warmup_batch_size',
+                'max_warmup_batches',
+                'warmup_sleep',
+            },
             exclude_none=True,
         )
 
@@ -143,7 +173,18 @@ class ParslHTExConfig(TapsExecutorConfig):
             initialize_logging=False,
             **options,
         )
-        return ParslPoolExecutor(config)
+        executor = ParslPoolExecutor(config)
+
+        if self.warmup:
+            warmup_executor(
+                executor,
+                self.min_connected_nodes,
+                self.warmup_batch_size,
+                self.max_warmup_batches,
+                self.warmup_sleep,
+            )
+
+        return executor
 
 
 class HTExConfig(BaseModel):

--- a/taps/executor/utils.py
+++ b/taps/executor/utils.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import functools
 import itertools
+import socket
 import sys
 import threading
+import time
 from concurrent.futures import Executor
 from concurrent.futures import Future
 from types import TracebackType
@@ -260,3 +262,42 @@ class FutureDependencyExecutor(Executor):
             self.executor.shutdown(wait=wait, cancel_futures=cancel_futures)
         else:  # pragma: <3.9 cover
             self.executor.shutdown(wait=wait)
+
+
+def warmup_executor(
+    executor: Executor,
+    min_connected_nodes: int,
+    batch_size: int,
+    max_batches: int,
+    batch_sleep: int,
+) -> None:
+    """Warm up an executor until enough nodes are seen.
+
+    Args:
+        executor: executor to warm up
+        min_connected_nodes: number of unique nodes necessary to consider
+            executor warm
+        batch_size: number of tasks to submit
+        max_batches: number of iterations to try to warm nodes
+        batch_sleep: time to sleep between tries
+
+    Raises:
+        Exception if executor cannot be warmed
+    """
+    hosts = set()
+    for _ in range(max_batches):
+        futures = [
+            executor.submit(socket.gethostname) for _ in range(batch_size)
+        ]
+        for f in futures:
+            hosts.add(f.result())
+
+        if len(hosts) >= min_connected_nodes:
+            return
+
+        time.sleep(batch_sleep)  # Does this need to be adjusted?
+
+    raise Exception(
+        f'Could not connect to {min_connected_nodes} after submitting '
+        f'{max_batches} of {batch_size} tasks.',
+    )

--- a/tests/executor/parsl_test.py
+++ b/tests/executor/parsl_test.py
@@ -82,6 +82,7 @@ def test_get_htex_executor(tmp_path: pathlib.Path, mock_monitoring) -> None:
             resource_monitoring_interval=1,
             hub_port=55055,
         ),
+        warmup=True,
     )
 
     with mock.patch(

--- a/tests/executor/utils_test.py
+++ b/tests/executor/utils_test.py
@@ -11,6 +11,7 @@ import pytest
 
 from taps.executor.utils import _Task
 from taps.executor.utils import FutureDependencyExecutor
+from taps.executor.utils import warmup_executor
 
 
 @pytest.fixture
@@ -170,3 +171,11 @@ def test_task_future_cancelled(
     assert task.task_future.cancel()
     with pytest.raises(CancelledError):
         client_future.result()
+
+
+def test_warmup_executor() -> None:
+    with ThreadPoolExecutor() as executor:
+        warmup_executor(executor, 1, 1, 1, 1)
+
+        with pytest.raises(Exception, match='Could not connect'):
+            warmup_executor(executor, 2, 1, 1, 1)


### PR DESCRIPTION
# Description
Distributed executors, specifically Parsl, may take some time for all of the nodes in the cluster to connect. This can cause artifacts at the beginning of a workload as the workers connect. The `warmup` tasks in the synthetic workload are designed to deal with these artifacts but are insufficient because workers that are early to connect may complete all of the tasks before the whole cluster is warm. This is a problem especially when scaling to a large number of nodes. Some executors have specific options that allow for waiting until all workers connect, for instance Dask's `wait-for-workers` option, but this is not available for other executors. Here we introduce a general mechanism to wait till some subset of nodes in the cluster have completed a task before proceeding. 

### Type of Change
- [x] Enhancement (non-breaking change which adds or improves functionality)

## Testing
Changed Parsl configuration tests to invoke warmup, and included a method to test warmup on a single node.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, documentation, enhancement, package, etc.).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
